### PR TITLE
fix: replace mocked with version from jest-mock

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -69,6 +69,10 @@
       "type": "build"
     },
     {
+      "name": "jest-mock",
+      "type": "build"
+    },
+    {
       "name": "jsii",
       "type": "build"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -289,7 +289,7 @@
           "exec": "npm install"
         },
         {
-          "exec": "npm update @aws-cdk/aws-synthetics-alpha @types/eslint @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib constructs esbuild eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema npm-check-updates standard-version ts-jest ts-morph ts-node typescript aws-cdk-lib constructs"
+          "exec": "npm update @aws-cdk/aws-synthetics-alpha @types/eslint @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib constructs esbuild eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jest-mock jsii jsii-diff jsii-docgen jsii-pacmak json-schema npm-check-updates standard-version ts-jest ts-morph ts-node typescript aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -80,6 +80,7 @@ const project = new AwsCdkConstructLibrary({
     'aws-cdk-lib@2.0.0',
     'constructs@10.0.5',
     'esbuild@^0.14.0',
+    'jest-mock',
     'ts-morph',
   ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint-plugin-import": "^2.25.3",
         "jest": "^27.3.1",
         "jest-junit": "^13",
+        "jest-mock": "*",
         "jsii": "^1.45.0",
         "jsii-diff": "^1.45.0",
         "jsii-docgen": "^3.8.31",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-import": "^2.25.3",
     "jest": "^27.3.1",
     "jest-junit": "^13",
+    "jest-mock": "^27.4.2",
     "jsii": "^1.45.0",
     "jsii-diff": "^1.45.0",
     "jsii-docgen": "^3.8.31",

--- a/test/bundler.test.ts
+++ b/test/bundler.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils';
+import { mocked } from 'jest-mock';
 import { EsbuildBundler } from '../src/bundler';
 import { BuildOptions, BuildResult } from '../src/esbuild-types';
 import { buildSync } from '../src/esbuild-wrapper';

--- a/test/code.test.ts
+++ b/test/code.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@aws-cdk/aws-synthetics-alpha';
 import { Stack } from 'aws-cdk-lib';
 import { Function, Runtime as LambdaRuntime } from 'aws-cdk-lib/aws-lambda';
-import { mocked } from 'ts-jest/utils';
+import { mocked } from 'jest-mock';
 import { JavaScriptCode, TypeScriptCode } from '../src/code';
 import { buildSync } from '../src/esbuild-wrapper';
 

--- a/test/inline-code.test.ts
+++ b/test/inline-code.test.ts
@@ -1,5 +1,5 @@
 import { Stack } from 'aws-cdk-lib';
-import { mocked } from 'ts-jest/utils';
+import { mocked } from 'jest-mock';
 import {
   InlineJavaScriptCode,
   InlineJsxCode,


### PR DESCRIPTION
Fixes deprecation warnings in tests