### PR TITLE
fix: only reset esbuild bin path if it was overwritten

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -195,7 +195,13 @@ export class EsbuildBundler {
           printBuildMessages(error as BuildFailure, { prefix: 'Build ' });
         }
 
-        process.env.ESBUILD_BINARY_PATH = originalEsbuildBinaryPath;
+        /**
+         * only reset `ESBUILD_BINARY_PATH` if it was explicitly set via the construct props
+         * since `esbuild` itself sometimes sets it (eg. when running in yarn 2 plug&play)
+         */ 
+        if (this.props.esbuildBinaryPath) {
+          process.env.ESBUILD_BINARY_PATH = originalEsbuildBinaryPath;
+        }
 
         return true;
       },


### PR DESCRIPTION
Fixes #189