### PR TITLE
docs(logo): set width and height in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./images/wordmark-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="./images/wordmark-light.svg">
-  <img height="100" src="./images/wordmark.svg" alt="cdk-esbuild">
+  <img src="./images/wordmark.svg" alt="cdk-esbuild">
 </picture>
 
 _CDK constructs for [esbuild](https://github.com/evanw/esbuild), an extremely fast JavaScript bundler_

--- a/images/wordmark-dark.svg
+++ b/images/wordmark-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="200" width="720">
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="100" viewBox="0 0 720 200">
     <style>
         text {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;

--- a/images/wordmark-light.svg
+++ b/images/wordmark-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="200" width="720">
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="100" viewBox="0 0 720 200">
     <style>
         text {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;

--- a/images/wordmark.svg
+++ b/images/wordmark.svg
@@ -1,8 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="200" width="720">
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="100" viewBox="0 0 720 200">
     <style>
         text {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-            font-weight: 700;
+            font-family: -apple-system, BlinkMacSystemFont, " Segoe UI", Helvetica, Arial, sans-serif;
+            font-weight:
+                700;
             font-size: 90px;
             fill: #191919;
         }


### PR DESCRIPTION
Fixes logo squished on mobile