### PR TITLE
fix: `esbuildBinaryPath` not working with `Code`, not available for `InlineCode`

### DIFF
--- a/API.md
+++ b/API.md
@@ -1334,6 +1334,20 @@ import { TransformerProps } from '@mrgrain/cdk-esbuild'
 const transformerProps: TransformerProps = { ... }
 ```
 
+##### `esbuildBinaryPath`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.TransformerProps.property.esbuildBinaryPath"></a>
+
+```typescript
+public readonly esbuildBinaryPath: string;
+```
+
+- *Type:* `string`
+
+Path to the binary used by esbuild.
+
+This is the same as setting the ESBUILD_BINARY_PATH environment variable.
+
+---
+
 ##### `transformFn`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.TransformerProps.property.transformFn"></a>
 
 ```typescript

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -61,9 +61,7 @@ export class EsbuildAsset<Props extends AssetProps> extends S3Asset {
   ) {
     const {
       assetHash,
-      copyDir,
       buildOptions: options = {},
-      buildFn,
     } = props;
     const entryPoints: string[] | Record<string, string> =
       typeof props.entryPoints === 'string' ? [props.entryPoints] : props.entryPoints;
@@ -110,9 +108,8 @@ export class EsbuildAsset<Props extends AssetProps> extends S3Asset {
       bundling: new EsbuildBundler(
         relativeEntryPoints,
         {
+          ...props,
           buildOptions,
-          copyDir,
-          buildFn,
         },
       ),
     });

--- a/src/esbuild-wrapper.ts
+++ b/src/esbuild-wrapper.ts
@@ -8,3 +8,28 @@ function esbuild() {
 export const buildSync = esbuild().buildSync;
 export const formatMessagesSync = esbuild().formatMessagesSync;
 export const transformSync = esbuild().transformSync;
+
+export function wrapWithEsbuildBinaryPath<T extends CallableFunction>(fn: T, esbuildBinaryPath?: string) {
+  if (!esbuildBinaryPath) {
+    return fn;
+  }
+
+  return (...args: unknown[]) => {
+    const originalEsbuildBinaryPath = process.env.ESBUILD_BINARY_PATH;
+    if (esbuildBinaryPath) {
+      process.env.ESBUILD_BINARY_PATH = esbuildBinaryPath;
+    }
+
+    const result = fn(...args);
+
+    /**
+     * only reset `ESBUILD_BINARY_PATH` if it was explicitly set via the construct props
+     * since `esbuild` itself sometimes sets it (eg. when running in yarn 2 plug&play)
+     */
+    if (esbuildBinaryPath) {
+      process.env.ESBUILD_BINARY_PATH = originalEsbuildBinaryPath;
+    }
+
+    return result;
+  };
+}

--- a/test/inline-code.test.ts
+++ b/test/inline-code.test.ts
@@ -134,4 +134,26 @@ describe('using transformerProps', () => {
       );
     });
   });
+
+  describe('given a custom esbuildBinaryPath', () => {
+    it('should set the ESBUILD_BINARY_PATH env variable', () => {
+      const mockLogger = jest.fn();
+      const customTransform = () => {
+        mockLogger(process.env.ESBUILD_BINARY_PATH);
+        return {
+          code: 'console.log("test");',
+          map: '',
+          warnings: [],
+        };
+      };
+
+      new InlineTypeScriptCode('let x: number = 1', {
+        transformFn: customTransform,
+        esbuildBinaryPath: 'dummy-binary',
+      });
+
+      expect(mockLogger).toHaveBeenCalledTimes(1);
+      expect(mockLogger).toHaveBeenCalledWith('dummy-binary');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #203