### PR TITLE
fix: `TransformOptions.tsconfigRaw` cannot receive an object

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -277,8 +277,39 @@ new TypeScriptSourceFile(project, 'src/esbuild-types.ts', {
     removeFromInterface('BuildOptions', ['entryPoints', 'stdin', 'plugins', 'watch']);
     esbuildTypes.getInterface('CommonOptions')?.getProperty('mangleProps')?.setType('any');
     esbuildTypes.getInterface('CommonOptions')?.getProperty('reserveProps')?.setType('any');
-    esbuildTypes.getInterface('TransformOptions')?.getProperty('tsconfigRaw')?.setType('string');
     esbuildTypes.getInterface('InitializeOptions')?.getProperty('wasmModule')?.setType('any');
+
+    const compileOptions = esbuildTypes.addInterface({
+      name: 'CompilerOptions',
+      isExported: true,
+      properties: [
+        ['jsxFactory', 'string'],
+        ['jsxFragmentFactory', 'string'],
+        ['useDefineForClassFields', 'boolean'],
+        ['importsNotUsedAsValues', "'remove' | 'preserve' | 'error'"],
+        ['preserveValueImports', 'boolean'],
+      ].map(([name, type]) => ({
+        name,
+        isReadonly: true,
+        hasQuestionToken: true,
+        type,
+      })),
+    });
+    const tsconfigOptions = esbuildTypes.addInterface(
+      {
+        name: 'TsconfigOptions',
+        isExported: true,
+        properties: [{
+          name: 'compilerOptions',
+          isReadonly: true,
+          hasQuestionToken: true,
+          type: compileOptions.getName(),
+        }],
+      });
+    esbuildTypes
+      ?.getInterface('TransformOptions')
+      ?.getProperty('tsconfigRaw')
+      ?.setType(`string | ${tsconfigOptions.getName()}`);
   },
 });
 

--- a/API.md
+++ b/API.md
@@ -1154,6 +1154,66 @@ The location of the code in S3 (mutually exclusive with `inlineCode` and `image`
 
 ---
 
+### CompilerOptions <a name="@mrgrain/cdk-esbuild.CompilerOptions"></a>
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { CompilerOptions } from '@mrgrain/cdk-esbuild'
+
+const compilerOptions: CompilerOptions = { ... }
+```
+
+##### `importsNotUsedAsValues`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.CompilerOptions.property.importsNotUsedAsValues"></a>
+
+```typescript
+public readonly importsNotUsedAsValues: string;
+```
+
+- *Type:* `string`
+
+---
+
+##### `jsxFactory`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.CompilerOptions.property.jsxFactory"></a>
+
+```typescript
+public readonly jsxFactory: string;
+```
+
+- *Type:* `string`
+
+---
+
+##### `jsxFragmentFactory`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.CompilerOptions.property.jsxFragmentFactory"></a>
+
+```typescript
+public readonly jsxFragmentFactory: string;
+```
+
+- *Type:* `string`
+
+---
+
+##### `preserveValueImports`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.CompilerOptions.property.preserveValueImports"></a>
+
+```typescript
+public readonly preserveValueImports: boolean;
+```
+
+- *Type:* `boolean`
+
+---
+
+##### `useDefineForClassFields`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.CompilerOptions.property.useDefineForClassFields"></a>
+
+```typescript
+public readonly useDefineForClassFields: boolean;
+```
+
+- *Type:* `boolean`
+
+---
+
 ### JavaScriptCodeProps <a name="@mrgrain/cdk-esbuild.JavaScriptCodeProps"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
@@ -1949,10 +2009,30 @@ Documentation: https://esbuild.github.io/api/#tree-shaking.
 ##### `tsconfigRaw`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.TransformOptions.property.tsconfigRaw"></a>
 
 ```typescript
-public readonly tsconfigRaw: string;
+public readonly tsconfigRaw: string | TsconfigOptions;
 ```
 
-- *Type:* `string`
+- *Type:* `string` | [`@mrgrain/cdk-esbuild.TsconfigOptions`](#@mrgrain/cdk-esbuild.TsconfigOptions)
+
+---
+
+### TsconfigOptions <a name="@mrgrain/cdk-esbuild.TsconfigOptions"></a>
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { TsconfigOptions } from '@mrgrain/cdk-esbuild'
+
+const tsconfigOptions: TsconfigOptions = { ... }
+```
+
+##### `compilerOptions`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.TsconfigOptions.property.compilerOptions"></a>
+
+```typescript
+public readonly compilerOptions: CompilerOptions;
+```
+
+- *Type:* [`@mrgrain/cdk-esbuild.CompilerOptions`](#@mrgrain/cdk-esbuild.CompilerOptions)
 
 ---
 

--- a/src/esbuild-types.ts
+++ b/src/esbuild-types.ts
@@ -242,7 +242,7 @@ export interface ServeResult {
 }
 
 export interface TransformOptions extends CommonOptions {
-  readonly tsconfigRaw?: string;
+  readonly tsconfigRaw?: string | TsconfigOptions;
 
   readonly sourcefile?: string;
   readonly loader?: Loader;
@@ -586,3 +586,15 @@ export interface InitializeOptions {
 }
 
 export let version: string;
+
+export interface CompilerOptions {
+  readonly jsxFactory?: string;
+  readonly jsxFragmentFactory?: string;
+  readonly useDefineForClassFields?: boolean;
+  readonly importsNotUsedAsValues?: 'remove' | 'preserve' | 'error';
+  readonly preserveValueImports?: boolean;
+}
+
+export interface TsconfigOptions {
+  readonly compilerOptions?: CompilerOptions;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@
 export {
   BuildOptions,
   TransformOptions,
+  TsconfigOptions,
+  CompilerOptions,
 } from './esbuild-types';
 
 export {


### PR DESCRIPTION
Previously this type was simplified to only accept a stringified version of the
tsconfig override. Now it also accepts a typed object.