### PR TITLE
chore: remove deprecated support of top-level TransformOptions on InlineCode classes

### DIFF
--- a/API.md
+++ b/API.md
@@ -2389,7 +2389,7 @@ Examples:
 
 - *Type:* [`@mrgrain/cdk-esbuild.BundlerProps`](#@mrgrain/cdk-esbuild.BundlerProps)
 
-Props to change the behaviour of the bundler.
+Props to change the behavior of the bundler.
 
 ---
 
@@ -2452,7 +2452,7 @@ public readonly props: BundlerProps;
 
 - *Type:* [`@mrgrain/cdk-esbuild.BundlerProps`](#@mrgrain/cdk-esbuild.BundlerProps)
 
-Props to change the behaviour of the bundler.
+Props to change the behavior of the bundler.
 
 ---
 
@@ -2684,7 +2684,7 @@ An implementation of `lambda.InlineCode` using the esbuild Transform API. Inline
 ```typescript
 import { InlineJavaScriptCode } from '@mrgrain/cdk-esbuild'
 
-new InlineJavaScriptCode(code: string, props?: TransformOptions | TransformerProps)
+new InlineJavaScriptCode(code: string, props?: TransformerProps)
 ```
 
 ##### `code`<sup>Required</sup> <a name="@mrgrain/cdk-esbuild.InlineJavaScriptCode.parameter.code"></a>
@@ -2697,11 +2697,9 @@ The inline code to be transformed.
 
 ##### `props`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.InlineJavaScriptCode.parameter.props"></a>
 
-- *Type:* [`@mrgrain/cdk-esbuild.TransformOptions`](#@mrgrain/cdk-esbuild.TransformOptions) | [`@mrgrain/cdk-esbuild.TransformerProps`](#@mrgrain/cdk-esbuild.TransformerProps)
+- *Type:* [`@mrgrain/cdk-esbuild.TransformerProps`](#@mrgrain/cdk-esbuild.TransformerProps)
 
-Support for `TransformOptions` is deprecated. Please provide `TransformerProps`!
-
-Props to change the behaviour of the transformer.
+Props to change the behavior of the transformer.
 
 Default values for `props.transformOptions`:
 - `loader='js'`
@@ -2749,7 +2747,7 @@ An implementation of `lambda.InlineCode` using the esbuild Transform API. Inline
 ```typescript
 import { InlineJsxCode } from '@mrgrain/cdk-esbuild'
 
-new InlineJsxCode(code: string, props?: TransformOptions | TransformerProps)
+new InlineJsxCode(code: string, props?: TransformerProps)
 ```
 
 ##### `code`<sup>Required</sup> <a name="@mrgrain/cdk-esbuild.InlineJsxCode.parameter.code"></a>
@@ -2762,11 +2760,9 @@ The inline code to be transformed.
 
 ##### `props`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.InlineJsxCode.parameter.props"></a>
 
-- *Type:* [`@mrgrain/cdk-esbuild.TransformOptions`](#@mrgrain/cdk-esbuild.TransformOptions) | [`@mrgrain/cdk-esbuild.TransformerProps`](#@mrgrain/cdk-esbuild.TransformerProps)
+- *Type:* [`@mrgrain/cdk-esbuild.TransformerProps`](#@mrgrain/cdk-esbuild.TransformerProps)
 
-Support for `TransformOptions` is deprecated. Please provide `TransformerProps`!
-
-Props to change the behaviour of the transformer.
+Props to change the behavior of the transformer.
 
 Default values for `transformOptions`:
 - `loader='jsx'`
@@ -2814,7 +2810,7 @@ An implementation of `lambda.InlineCode` using the esbuild Transform API. Inline
 ```typescript
 import { InlineTsxCode } from '@mrgrain/cdk-esbuild'
 
-new InlineTsxCode(code: string, props?: TransformOptions | TransformerProps)
+new InlineTsxCode(code: string, props?: TransformerProps)
 ```
 
 ##### `code`<sup>Required</sup> <a name="@mrgrain/cdk-esbuild.InlineTsxCode.parameter.code"></a>
@@ -2827,11 +2823,9 @@ The inline code to be transformed.
 
 ##### `props`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.InlineTsxCode.parameter.props"></a>
 
-- *Type:* [`@mrgrain/cdk-esbuild.TransformOptions`](#@mrgrain/cdk-esbuild.TransformOptions) | [`@mrgrain/cdk-esbuild.TransformerProps`](#@mrgrain/cdk-esbuild.TransformerProps)
+- *Type:* [`@mrgrain/cdk-esbuild.TransformerProps`](#@mrgrain/cdk-esbuild.TransformerProps)
 
-Support for `TransformOptions` is deprecated. Please provide `TransformerProps`!
-
-Props to change the behaviour of the transformer.
+Props to change the behavior of the transformer.
 
 Default values for `transformOptions`:
 - `loader='tsx'`
@@ -2879,7 +2873,7 @@ An implementation of `lambda.InlineCode` using the esbuild Transform API. Inline
 ```typescript
 import { InlineTypeScriptCode } from '@mrgrain/cdk-esbuild'
 
-new InlineTypeScriptCode(code: string, props?: TransformOptions | TransformerProps)
+new InlineTypeScriptCode(code: string, props?: TransformerProps)
 ```
 
 ##### `code`<sup>Required</sup> <a name="@mrgrain/cdk-esbuild.InlineTypeScriptCode.parameter.code"></a>
@@ -2892,11 +2886,9 @@ The inline code to be transformed.
 
 ##### `props`<sup>Optional</sup> <a name="@mrgrain/cdk-esbuild.InlineTypeScriptCode.parameter.props"></a>
 
-- *Type:* [`@mrgrain/cdk-esbuild.TransformOptions`](#@mrgrain/cdk-esbuild.TransformOptions) | [`@mrgrain/cdk-esbuild.TransformerProps`](#@mrgrain/cdk-esbuild.TransformerProps)
+- *Type:* [`@mrgrain/cdk-esbuild.TransformerProps`](#@mrgrain/cdk-esbuild.TransformerProps)
 
-Support for `TransformOptions` is deprecated. Please provide `TransformerProps`!
-
-Props to change the behaviour of the transformer.
+Props to change the behavior of the transformer.
 
 Default values for `transformOptions`:
 - `loader='ts'`

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -162,7 +162,7 @@ export class EsbuildBundler {
     public readonly entryPoints: EntryPoints,
 
     /**
-     * Props to change the behaviour of the bundler.
+     * Props to change the behavior of the bundler.
      *
      * @stability experimental
      */

--- a/src/inline-code.ts
+++ b/src/inline-code.ts
@@ -102,28 +102,7 @@ abstract class BaseInlineCode extends InlineCode {
   }
 }
 
-function instanceOfTransformerProps(object: any): object is TransformerProps {
-  return [
-    'transformOptions',
-    'transformFn',
-    'esbuildBinaryPath',
-    'esbuildModulePath',
-  ].reduce(
-    (isTransformerProps: boolean, propToCheck: string): boolean =>
-      (isTransformerProps || (propToCheck in object)),
-    false,
-  );
-}
-
-function transformerProps(loader: Loader, props?: TransformerProps | TransformOptions): TransformerProps {
-  if (!props) {
-    return { transformOptions: { loader } };
-  }
-
-  if (!instanceOfTransformerProps(props) ) {
-    return { transformOptions: { loader, ...props } };
-  }
-
+function transformerProps(loader: Loader, props: TransformerProps = {}): TransformerProps {
   return {
     ...props,
     transformOptions: {
@@ -132,7 +111,6 @@ function transformerProps(loader: Loader, props?: TransformerProps | TransformOp
     },
   };
 }
-
 
 /**
  * An implementation of `lambda.InlineCode` using the esbuild Transform API. Inline function code is limited to 4 KiB after transformation.
@@ -148,9 +126,7 @@ export class InlineJavaScriptCode extends BaseInlineCode {
      */
     code: string,
     /**
-     * Support for `TransformOptions` is deprecated. Please provide `TransformerProps`!
-     *
-     * Props to change the behaviour of the transformer.
+     * Props to change the behavior of the transformer.
      *
      * Default values for `props.transformOptions`:
      * - `loader='js'`
@@ -158,7 +134,7 @@ export class InlineJavaScriptCode extends BaseInlineCode {
      * @see https://esbuild.github.io/api/#transform-api
      * @stability experimental
      */
-    props?: TransformerProps | TransformOptions,
+    props?: TransformerProps,
   ) {
 
     super(code, transformerProps('js', props));
@@ -179,9 +155,7 @@ export class InlineJsxCode extends BaseInlineCode {
      */
     code: string,
     /**
-     * Support for `TransformOptions` is deprecated. Please provide `TransformerProps`!
-     *
-     * Props to change the behaviour of the transformer.
+     * Props to change the behavior of the transformer.
      *
      * Default values for `transformOptions`:
      * - `loader='jsx'`
@@ -189,7 +163,7 @@ export class InlineJsxCode extends BaseInlineCode {
      * @see https://esbuild.github.io/api/#transform-api
      * @stability experimental
      */
-    props?: TransformerProps | TransformOptions,
+    props?: TransformerProps,
   ) {
     super(code, transformerProps('jsx', props));
   }
@@ -209,9 +183,7 @@ export class InlineTypeScriptCode extends BaseInlineCode {
      */
     code: string,
     /**
-     * Support for `TransformOptions` is deprecated. Please provide `TransformerProps`!
-     *
-     * Props to change the behaviour of the transformer.
+     * Props to change the behavior of the transformer.
      *
      * Default values for `transformOptions`:
      * - `loader='ts'`
@@ -219,7 +191,7 @@ export class InlineTypeScriptCode extends BaseInlineCode {
      * @see https://esbuild.github.io/api/#transform-api
      * @stability experimental
      */
-    props?: TransformerProps | TransformOptions,
+    props?: TransformerProps,
   ) {
     super(code, transformerProps('ts', props));
   }
@@ -239,9 +211,7 @@ export class InlineTsxCode extends BaseInlineCode {
      */
     code: string,
     /**
-     * Support for `TransformOptions` is deprecated. Please provide `TransformerProps`!
-     *
-     * Props to change the behaviour of the transformer.
+     * Props to change the behavior of the transformer.
      *
      * Default values for `transformOptions`:
      * - `loader='tsx'`
@@ -249,7 +219,7 @@ export class InlineTsxCode extends BaseInlineCode {
      * @see https://esbuild.github.io/api/#transform-api
      * @stability experimental
      */
-    props?: TransformerProps | TransformOptions,
+    props?: TransformerProps,
   ) {
     super(code, transformerProps('tsx', props));
   }

--- a/test/inline-code.test.ts
+++ b/test/inline-code.test.ts
@@ -12,23 +12,6 @@ import { EsbuildProvider } from '../src/esbuild-provider';
 
 const providerSpy = jest.spyOn(EsbuildProvider, '_require');
 
-describe('using transformOptions', () => {
-  describe('given a banner code', () => {
-    it('should add the banner before the code', () => {
-      const code = new InlineJavaScriptCode(
-        "const banana = 'fruit' ?? 'vegetable'",
-        {
-          banner: '/** BANNER */',
-        },
-      );
-
-      const { inlineCode } = code.bind(new Stack());
-
-      expect(inlineCode).toBe('/** BANNER */\nconst banana = "fruit";\n');
-    });
-  });
-});
-
 describe('using transformerProps', () => {
   describe('given some js code', () => {
     it('should transform the code', () => {


### PR DESCRIPTION
BREAKING CHANGE: `InlineCode` classes now only take `TransformerProps` as second argument. Please provide any transform options via `props.transformOptions`. Previously `TransformOptions` could be provided at the top-level.