### PR TITLE
feat: `InlineJavaScriptCode` and `InlineTypeScriptCode` transform to CommonJS and Node by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -2703,6 +2703,8 @@ Props to change the behavior of the transformer.
 
 Default values for `props.transformOptions`:
 - `loader='js'`
+- `platform=node`
+- `target=nodeX` with X being the major node version running locally
 
 > https://esbuild.github.io/api/#transform-api
 
@@ -2766,6 +2768,8 @@ Props to change the behavior of the transformer.
 
 Default values for `transformOptions`:
 - `loader='ts'`
+- `platform=node`
+- `target=nodeX` with X being the major node version running locally
 
 > https://esbuild.github.io/api/#transform-api
 

--- a/src/code.ts
+++ b/src/code.ts
@@ -10,10 +10,7 @@ import {
 } from './asset';
 import { EntryPoints } from './bundler';
 import { BuildOptions } from './esbuild-types';
-
-function nodeMajorVersion(): number {
-  return parseInt(process.versions.node.split('.')[0], 10);
-}
+import { defaultPlatformProps } from './utils';
 
 export { CodeConfig } from 'aws-cdk-lib/aws-lambda';
 export interface JavaScriptCodeProps extends AssetBaseProps {};
@@ -81,12 +78,7 @@ export class EsbuildCode<
   ) {
     super();
 
-    const defaultOptions: Partial<BuildOptions> = {
-      ...(!props.buildOptions?.platform ||
-      props.buildOptions?.platform === 'node'
-        ? { platform: 'node', target: 'node' + nodeMajorVersion() }
-        : {}),
-    };
+    const defaultOptions: Partial<BuildOptions> = defaultPlatformProps(props.buildOptions);
 
     this.props = {
       ...props,

--- a/src/inline-code.ts
+++ b/src/inline-code.ts
@@ -3,7 +3,7 @@ import { CodeConfig, InlineCode } from 'aws-cdk-lib/aws-lambda';
 import { Construct, Node } from 'constructs';
 import { EsbuildProvider } from './esbuild-provider';
 import { TransformOptions, Loader } from './esbuild-types';
-import { isEsbuildError } from './utils';
+import { defaultPlatformProps, isEsbuildError } from './utils';
 
 /**
  * @stability stable
@@ -107,6 +107,8 @@ function transformerProps(loader: Loader, props: TransformerProps = {}): Transfo
     ...props,
     transformOptions: {
       loader,
+      format: 'cjs',
+      ...defaultPlatformProps(props.transformOptions),
       ...props.transformOptions,
     },
   };
@@ -130,13 +132,14 @@ export class InlineJavaScriptCode extends BaseInlineCode {
      *
      * Default values for `props.transformOptions`:
      * - `loader='js'`
+     * - `platform=node`
+     * - `target=nodeX` with X being the major node version running locally
      *
      * @see https://esbuild.github.io/api/#transform-api
      * @stability stable
      */
     props?: TransformerProps,
   ) {
-
     super(code, transformerProps('js', props));
   }
 }
@@ -160,6 +163,8 @@ export class InlineTypeScriptCode extends BaseInlineCode {
      *
      * Default values for `transformOptions`:
      * - `loader='ts'`
+     * - `platform=node`
+     * - `target=nodeX` with X being the major node version running locally
      *
      * @see https://esbuild.github.io/api/#transform-api
      * @stability stable

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,24 @@
+import { BuildOptions, Platform, TransformOptions } from './esbuild-types';
+
 export function isEsbuildError(error: unknown): boolean {
   return !!error
   && typeof error == 'object'
   && error != null
   && 'errors' in error
   && 'warnings' in error;
+}
+
+export function nodeMajorVersion(): number {
+  return parseInt(process.versions.node.split('.')[0], 10);
+}
+
+export function defaultPlatformProps(options?: BuildOptions | TransformOptions): {
+  platform?: Platform;
+  target?: string | string[];
+} {
+  if (!options?.platform || options?.platform === 'node') {
+    return { platform: 'node', target: 'node' + nodeMajorVersion() };
+  }
+
+  return {};
 }

--- a/test/inline-code.test.ts
+++ b/test/inline-code.test.ts
@@ -10,182 +10,257 @@ import { EsbuildProvider } from '../src/esbuild-provider';
 
 const providerSpy = jest.spyOn(EsbuildProvider, '_require');
 
-describe('using transformerProps', () => {
-  describe('given some js code', () => {
-    it('should transform the code', () => {
-      const code = new InlineJavaScriptCode(
-        "const banana = 'fruit' ?? 'vegetable'",
-      );
+describe('given the default options', () => {
+  it('should target cjs and node', () => {
+    const transformFn = jest.fn().mockReturnValue(({ code: '' }));
 
-      const stack = new Stack();
-      const { inlineCode } = code.bind(stack);
-
-      expect(stack.resolve(inlineCode)).toBe('const banana = "fruit";\n');
+    const code = new InlineTypeScriptCode('let x: number = 1', {
+      transformFn,
     });
+    code.bind(new Stack());
+
+    expect(mocked(transformFn)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        loader: 'ts',
+        format: 'cjs',
+        platform: 'node',
+        target: expect.stringContaining('node'),
+      }),
+    );
+  });
+});
+
+describe('given some non default options', () => {
+  it('should override the default options', () => {
+    const transformFn = jest.fn().mockReturnValue(({ code: '' }));
+
+    const code = new InlineJavaScriptCode('var number = 1', {
+      transformFn,
+      transformOptions: {
+        loader: 'jsx',
+        format: 'esm',
+        platform: 'neutral',
+        target: 'deno',
+      },
+    });
+    code.bind(new Stack());
+
+    expect(mocked(transformFn)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        loader: 'jsx',
+        format: 'esm',
+        platform: 'neutral',
+        target: 'deno',
+      }),
+    );
+  });
+});
+
+describe('given some js code', () => {
+  it('should transform the code', () => {
+    const code = new InlineJavaScriptCode(
+      "const banana = 'fruit' ?? 'vegetable'",
+    );
+
+    const stack = new Stack();
+    const { inlineCode } = code.bind(stack);
+
+    expect(stack.resolve(inlineCode)).toBe('const banana = "fruit";\n');
+  });
+});
+
+describe('given some ts code', () => {
+  it('should transform the code', () => {
+    const code = new InlineTypeScriptCode('let x: number = 1');
+
+    const { inlineCode } = code.bind(new Stack());
+
+    expect(inlineCode).toBe('let x = 1;\n');
   });
 
-  describe('given some ts code', () => {
-    it('should transform the code', () => {
-      const code = new InlineTypeScriptCode('let x: number = 1');
+  it('should announce the transforming step', () => {
+    const processStdErrWriteSpy = jest.spyOn(process.stderr, 'write');
+    const stack = new Stack(new App(), 'Stack');
+    const code = new InlineTypeScriptCode('let x: number = 1');
 
-      const { inlineCode } = code.bind(new Stack());
-
-      expect(inlineCode).toBe('let x = 1;\n');
+    new Function(stack, 'MyFunction', {
+      runtime: Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code,
     });
 
-    it('should announce the transforming step', () => {
-      const processStdErrWriteSpy = jest.spyOn(process.stderr, 'write');
-      const stack = new Stack(new App(), 'Stack');
-      const code = new InlineTypeScriptCode('let x: number = 1');
-
-      new Function(stack, 'MyFunction', {
-        runtime: Runtime.NODEJS_14_X,
-        handler: 'index.handler',
-        code,
-      });
-
-      expect(processStdErrWriteSpy).toHaveBeenCalledWith(
-        'Transforming inline code Stack/MyFunction/InlineTypeScriptCode...\n',
-      );
-      processStdErrWriteSpy.mockRestore();
-    });
-
-    it('should not do the work twice', () => {
-      const processStdErrWriteSpy = jest.spyOn(process.stderr, 'write');
-      const transformFn = jest.fn(esbuild.transformSync);
-
-      const stack = new Stack(new App(), 'Stack');
-      const code = new InlineTypeScriptCode('let x: number = 1', {
-        transformFn,
-      });
-
-      new Function(stack, 'One', {
-        runtime: Runtime.NODEJS_14_X,
-        handler: 'index.handler',
-        code,
-      });
-
-      new Function(stack, 'Two', {
-        runtime: Runtime.NODEJS_14_X,
-        handler: 'index.handler',
-        code,
-      });
-
-      expect(transformFn).toHaveBeenCalledTimes(1);
-      expect(processStdErrWriteSpy).toHaveBeenCalledWith(
-        'Transforming inline code Stack/One/InlineTypeScriptCode...\n',
-      );
-      expect(processStdErrWriteSpy).toHaveBeenCalledWith(
-        'Transforming inline code Stack/Two/InlineTypeScriptCode...\n',
-      );
-      processStdErrWriteSpy.mockRestore();
-    });
+    expect(processStdErrWriteSpy).toHaveBeenCalledWith(
+      'Transforming inline code Stack/MyFunction/InlineTypeScriptCode...\n',
+    );
+    processStdErrWriteSpy.mockRestore();
   });
 
-  describe('given some broken ts code', () => {
-    it('should throws', () => {
-      expect(() => {
-        const code = new InlineTypeScriptCode('let : d ===== 1');
-        code.bind(new Stack());
-      }).toThrowError('Esbuild failed to transform InlineTypeScriptCode');
+  it('should not do the work twice', () => {
+    const processStdErrWriteSpy = jest.spyOn(process.stderr, 'write');
+    const transformFn = jest.fn(esbuild.transformSync);
+
+    const stack = new Stack(new App(), 'Stack');
+    const code = new InlineTypeScriptCode('let x: number = 1', {
+      transformFn,
     });
 
-    // Currently no way to capture esbuild output,
-    // See https://github.com/evanw/esbuild/issues/2466
-    it.skip('should display an error', () => {
-      const processStdErrWriteSpy = jest.spyOn(process.stderr, 'write');
-
-      expect(() => {
-        const code = new InlineTypeScriptCode('let : d ===== 1');
-        code.bind(new Stack());
-      }).toThrowError('Esbuild failed to transform InlineTypeScriptCode');
-
-      expect(processStdErrWriteSpy).toBeCalledWith(expect.stringContaining('Unexpected "=="'));
-
-      processStdErrWriteSpy.mockRestore();
+    new Function(stack, 'One', {
+      runtime: Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code,
     });
+
+    new Function(stack, 'Two', {
+      runtime: Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code,
+    });
+
+    expect(transformFn).toHaveBeenCalledTimes(1);
+    expect(processStdErrWriteSpy).toHaveBeenCalledWith(
+      'Transforming inline code Stack/One/InlineTypeScriptCode...\n',
+    );
+    expect(processStdErrWriteSpy).toHaveBeenCalledWith(
+      'Transforming inline code Stack/Two/InlineTypeScriptCode...\n',
+    );
+    processStdErrWriteSpy.mockRestore();
+  });
+});
+
+describe('given some broken ts code', () => {
+  it('should throws', () => {
+    expect(() => {
+      const code = new InlineTypeScriptCode('let : d ===== 1');
+      code.bind(new Stack());
+    }).toThrowError('Esbuild failed to transform InlineTypeScriptCode');
   });
 
-  describe('given a banner code', () => {
-    it('should add the banner before the code', () => {
-      const code = new InlineJavaScriptCode(
-        "const banana = 'fruit' ?? 'vegetable'",
-        {
-          transformOptions: { banner: '/** BANNER */' },
-        },
-      );
+  // Currently no way to capture esbuild output,
+  // See https://github.com/evanw/esbuild/issues/2466
+  it.skip('should display an error', () => {
+    const processStdErrWriteSpy = jest.spyOn(process.stderr, 'write');
 
-      const { inlineCode } = code.bind(new Stack());
+    expect(() => {
+      const code = new InlineTypeScriptCode('let : d ===== 1');
+      code.bind(new Stack());
+    }).toThrowError('Esbuild failed to transform InlineTypeScriptCode');
 
-      expect(inlineCode).toBe('/** BANNER */\nconst banana = "fruit";\n');
-    });
+    expect(processStdErrWriteSpy).toBeCalledWith(expect.stringContaining('Unexpected "=="'));
+
+    processStdErrWriteSpy.mockRestore();
   });
+});
 
-  describe('given a custom transform function', () => {
-    it('should call my transform function', () => {
-      const customTransform = jest.fn().mockImplementation(() => ({
+describe('given a banner code', () => {
+  it('should add the banner before the code', () => {
+    const code = new InlineJavaScriptCode(
+      "const banana = 'fruit' ?? 'vegetable'",
+      {
+        transformOptions: { banner: '/** BANNER */' },
+      },
+    );
+
+    const { inlineCode } = code.bind(new Stack());
+
+    expect(inlineCode).toBe('/** BANNER */\nconst banana = "fruit";\n');
+  });
+});
+
+describe('given a custom transform function', () => {
+  it('should call my transform function', () => {
+    const customTransform = jest.fn().mockImplementation(() => ({
+      code: 'console.log("test");',
+      map: '',
+      warnings: [],
+    }));
+
+    const code = new InlineTypeScriptCode('let x: number = 1', {
+      transformFn: customTransform,
+    });
+    const { inlineCode } = code.bind(new Stack());
+
+    expect(inlineCode).toBe('console.log("test");');
+    expect(mocked(customTransform)).toHaveBeenCalledWith(
+      expect.stringContaining('let x: number = 1'),
+      expect.anything(),
+    );
+  });
+});
+
+describe('given a custom esbuildBinaryPath', () => {
+  it('should set the ESBUILD_BINARY_PATH env variable', () => {
+    const mockLogger = jest.fn();
+    const customTransform = () => {
+      mockLogger(process.env.ESBUILD_BINARY_PATH);
+      return {
         code: 'console.log("test");',
         map: '',
         warnings: [],
-      }));
+      };
+    };
 
-      const code = new InlineTypeScriptCode('let x: number = 1', {
-        transformFn: customTransform,
-      });
-      const { inlineCode } = code.bind(new Stack());
+    const code = new InlineTypeScriptCode('let x: number = 1', {
+      transformFn: customTransform,
+      esbuildBinaryPath: 'dummy-binary',
+    });
+    code.bind(new Stack());
 
-      expect(inlineCode).toBe('console.log("test");');
-      expect(mocked(customTransform)).toHaveBeenCalledWith(
-        expect.stringContaining('let x: number = 1'),
-        expect.anything(),
-      );
+    expect(mockLogger).toHaveBeenCalledTimes(1);
+    expect(mockLogger).toHaveBeenCalledWith('dummy-binary');
+  });
+});
+
+describe('with an esbuild module path from', () => {
+  beforeEach(() => {
+    providerSpy.mockClear();
+    providerSpy.mockReturnValue(esbuild);
+  });
+  afterAll(() => {
+    providerSpy.mockRestore();
+  });
+
+  describe('the default', () => {
+    it('should call the esbuild provider with "esbuild"', () => {
+      const code = new InlineTypeScriptCode('let x: number = 1');
+      code.bind(new Stack());
+
+      expect(providerSpy).toHaveBeenCalledTimes(1);
+      expect(providerSpy).toHaveBeenCalledWith('esbuild');
     });
   });
 
-  describe('given a custom esbuildBinaryPath', () => {
-    it('should set the ESBUILD_BINARY_PATH env variable', () => {
-      const mockLogger = jest.fn();
-      const customTransform = () => {
-        mockLogger(process.env.ESBUILD_BINARY_PATH);
-        return {
-          code: 'console.log("test");',
-          map: '',
-          warnings: [],
-        };
-      };
-
+  describe('`esbuildModulePath` prop', () => {
+    it('should use the path from the prop', () => {
       const code = new InlineTypeScriptCode('let x: number = 1', {
-        transformFn: customTransform,
-        esbuildBinaryPath: 'dummy-binary',
+        esbuildModulePath: '/expected/path/from/prop',
       });
       code.bind(new Stack());
 
-      expect(mockLogger).toHaveBeenCalledTimes(1);
-      expect(mockLogger).toHaveBeenCalledWith('dummy-binary');
+      expect(providerSpy).toHaveBeenCalledTimes(1);
+      expect(providerSpy).toHaveBeenCalledWith('/expected/path/from/prop');
     });
   });
 
-  describe('with an esbuild module path from', () => {
+  describe('`CDK_ESBUILD_MODULE_PATH` env var', () => {
     beforeEach(() => {
-      providerSpy.mockClear();
-      providerSpy.mockReturnValue(esbuild);
+      process.env.CDK_ESBUILD_MODULE_PATH = '/expected/path/from/env/var';
     });
-    afterAll(() => {
-      providerSpy.mockRestore();
-    });
-
-    describe('the default', () => {
-      it('should call the esbuild provider with "esbuild"', () => {
-        const code = new InlineTypeScriptCode('let x: number = 1');
-        code.bind(new Stack());
-
-        expect(providerSpy).toHaveBeenCalledTimes(1);
-        expect(providerSpy).toHaveBeenCalledWith('esbuild');
-      });
+    afterEach(() => {
+      delete process.env.CDK_ESBUILD_MODULE_PATH;
     });
 
-    describe('`esbuildModulePath` prop', () => {
-      it('should use the path from the prop', () => {
+    it('should use the path from the env var', () => {
+      const code = new InlineTypeScriptCode('let x: number = 1');
+      code.bind(new Stack());
+
+      expect(providerSpy).toHaveBeenCalledTimes(1);
+      expect(providerSpy).toHaveBeenCalledWith('/expected/path/from/env/var');
+    });
+
+    describe('and `esbuildModulePath` prop', () => {
+      it('should prefer the path from prop', () => {
         const code = new InlineTypeScriptCode('let x: number = 1', {
           esbuildModulePath: '/expected/path/from/prop',
         });
@@ -195,121 +270,92 @@ describe('using transformerProps', () => {
         expect(providerSpy).toHaveBeenCalledWith('/expected/path/from/prop');
       });
     });
+  });
+});
 
-    describe('`CDK_ESBUILD_MODULE_PATH` env var', () => {
-      beforeEach(() => {
-        process.env.CDK_ESBUILD_MODULE_PATH = '/expected/path/from/env/var';
+describe('with logLevel', () => {
+  describe('not provided', () => {
+    it('should default to "warning"', () => {
+      const transformFn = jest.fn(esbuild.transformSync);
+      const code = new InlineJavaScriptCode("const fruit = 'banana';", {
+        transformFn,
       });
-      afterEach(() => {
-        delete process.env.CDK_ESBUILD_MODULE_PATH;
-      });
+      code.bind(new Stack());
 
-      it('should use the path from the env var', () => {
-        const code = new InlineTypeScriptCode('let x: number = 1');
-        code.bind(new Stack());
-
-        expect(providerSpy).toHaveBeenCalledTimes(1);
-        expect(providerSpy).toHaveBeenCalledWith('/expected/path/from/env/var');
-      });
-
-      describe('and `esbuildModulePath` prop', () => {
-        it('should prefer the path from prop', () => {
-          const code = new InlineTypeScriptCode('let x: number = 1', {
-            esbuildModulePath: '/expected/path/from/prop',
-          });
-          code.bind(new Stack());
-
-          expect(providerSpy).toHaveBeenCalledTimes(1);
-          expect(providerSpy).toHaveBeenCalledWith('/expected/path/from/prop');
-        });
-      });
+      expect(transformFn).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        logLevel: 'warning',
+      }));
     });
   });
 
-  describe('with logLevel', () => {
-    describe('not provided', () => {
-      it('should default to "warning"', () => {
-        const transformFn = jest.fn(esbuild.transformSync);
-        const code = new InlineJavaScriptCode("const fruit = 'banana';", {
-          transformFn,
-        });
-        code.bind(new Stack());
-
-        expect(transformFn).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
-          logLevel: 'warning',
-        }));
-      });
-    });
-
-    describe('provided', () => {
-      it('should use the provided logLevel', () => {
-        const transformFn = jest.fn(esbuild.transformSync);
-        const code = new InlineJavaScriptCode("const fruit = 'banana';", {
-          transformFn,
-          transformOptions: {
-            logLevel: 'silent',
-          },
-        });
-        code.bind(new Stack());
-
-        expect(transformFn).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+  describe('provided', () => {
+    it('should use the provided logLevel', () => {
+      const transformFn = jest.fn(esbuild.transformSync);
+      const code = new InlineJavaScriptCode("const fruit = 'banana';", {
+        transformFn,
+        transformOptions: {
           logLevel: 'silent',
-        }));
+        },
       });
+      code.bind(new Stack());
+
+      expect(transformFn).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        logLevel: 'silent',
+      }));
     });
   });
+});
 
-  describe('with process.env.NO_COLOR', () => {
-    describe.each([
-      ['1', true],
-      ['0', true], // NO_COLOR spec says any value
-      ['', undefined], // except empty string
-      [undefined, undefined],
-    ])('set to %j', (noColorValue, derivedColor) => {
-      beforeEach(() => {
-        process.env.NO_COLOR = noColorValue;
-        if (noColorValue === undefined) {
-          delete process.env.NO_COLOR;
-        }
-      });
-      afterEach(() => {
+describe('with process.env.NO_COLOR', () => {
+  describe.each([
+    ['1', true],
+    ['0', true], // NO_COLOR spec says any value
+    ['', undefined], // except empty string
+    [undefined, undefined],
+  ])('set to %j', (noColorValue, derivedColor) => {
+    beforeEach(() => {
+      process.env.NO_COLOR = noColorValue;
+      if (noColorValue === undefined) {
         delete process.env.NO_COLOR;
+      }
+    });
+    afterEach(() => {
+      delete process.env.NO_COLOR;
+    });
+
+    it(`should set the color option to "${derivedColor}"`, () => {
+      const transformFn = jest.fn(esbuild.transformSync);
+
+      const code = new InlineTypeScriptCode('let x: number = 1', {
+        transformFn,
       });
+      code.bind(new Stack());
 
-      it(`should set the color option to "${derivedColor}"`, () => {
-        const transformFn = jest.fn(esbuild.transformSync);
+      expect(transformFn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          color: derivedColor,
+        }),
+      );
+    });
 
-        const code = new InlineTypeScriptCode('let x: number = 1', {
-          transformFn,
-        });
-        code.bind(new Stack());
+    it('should respect an explicit option', () => {
+      const transformFn = jest.fn(esbuild.transformSync);
 
-        expect(transformFn).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.objectContaining({
-            color: derivedColor,
-          }),
-        );
+      const code = new InlineTypeScriptCode('let x: number = 1', {
+        transformFn,
+        transformOptions: {
+          color: false,
+        },
       });
+      code.bind(new Stack());
 
-      it('should respect an explicit option', () => {
-        const transformFn = jest.fn(esbuild.transformSync);
-
-        const code = new InlineTypeScriptCode('let x: number = 1', {
-          transformFn,
-          transformOptions: {
-            color: false,
-          },
-        });
-        code.bind(new Stack());
-
-        expect(transformFn).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.objectContaining({
-            color: false,
-          }),
-        );
-      });
+      expect(transformFn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          color: false,
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: The default format and platform InlineXCode classes has been changed to CommonJS and Node. If you are using these classes to create browser or ESM compatible code, please update `format` and `platform` on `props.transformOptions` to your desired values.