### PR TITLE
chore: upgrade minium version requirement for `aws-cdk-lib`

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.0.0",
+      "version": "2.12.0",
       "type": "build"
     },
     {
@@ -138,7 +138,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.0.0",
+      "version": "^2.12.0",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -91,7 +91,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   }],
 
   // Dependencies
-  cdkVersion: '2.0.0',
+  cdkVersion: '2.12.0',
   devDeps: [
     '@aws-cdk/aws-synthetics-alpha@2.0.0-alpha.11',
     '@types/eslint',

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Only the latest release of each major version is supported.
 | v1             | ^1.99.0     | :x:                                                           |
 | v2             | ^1.99.0     | Security updates and critical bug fixes until June 1, 2023    |
 | v3             | ^2.0.0      | Security updates and critical bug fixes until January 1, 2024 |
-| v4             | ^2.0.0      | :white_check_mark:                                            |
+| v4             | ^2.12.0     | :white_check_mark:                                            |
 
 ## Reporting a Vulnerability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/node": "^14",
         "@typescript-eslint/eslint-plugin": "^5",
         "@typescript-eslint/parser": "^5",
-        "aws-cdk-lib": "2.0.0",
+        "aws-cdk-lib": "2.12.0",
         "constructs": "10.0.5",
         "esbuild": "^0.16.0",
         "eslint": "^8",
@@ -42,7 +42,7 @@
         "esbuild": "^0.16.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.0.0",
+        "aws-cdk-lib": "^2.12.0",
         "constructs": "^10.0.5"
       }
     },
@@ -2530,9 +2530,9 @@
       "dev": true
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.0.0.tgz",
-      "integrity": "sha512-ETom3THcblmS3GSoS6rb2AGy7HZpcpoHvwNlxeVIVbmGOiKrrqjvECK2uOJtNboV/vDTHHjx/s/1SwptLo9dlg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.12.0.tgz",
+      "integrity": "sha512-ot2gJycvHy9OqKkiDVSOP1QNOxapNUbjahEWSp0Mdxkweark0OdrzBv4JNaJYfGMn8IdZZ6FV/hpsi4MYHQ/+w==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2549,9 +2549,9 @@
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.1.9",
+        "ignore": "^5.2.0",
         "jsonschema": "^1.4.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "punycode": "^2.1.1",
         "semver": "^7.3.5",
         "yaml": "1.10.2"
@@ -2625,13 +2625,13 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.8",
+      "version": "4.2.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.1.9",
+      "version": "5.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2673,7 +2673,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14463,17 +14463,17 @@
       "dev": true
     },
     "aws-cdk-lib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.0.0.tgz",
-      "integrity": "sha512-ETom3THcblmS3GSoS6rb2AGy7HZpcpoHvwNlxeVIVbmGOiKrrqjvECK2uOJtNboV/vDTHHjx/s/1SwptLo9dlg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.12.0.tgz",
+      "integrity": "sha512-ot2gJycvHy9OqKkiDVSOP1QNOxapNUbjahEWSp0Mdxkweark0OdrzBv4JNaJYfGMn8IdZZ6FV/hpsi4MYHQ/+w==",
       "dev": true,
       "requires": {
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.1.9",
+        "ignore": "^5.2.0",
         "jsonschema": "^1.4.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "punycode": "^2.1.1",
         "semver": "^7.3.5",
         "yaml": "1.10.2"
@@ -14525,12 +14525,12 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.8",
+          "version": "4.2.9",
           "bundled": true,
           "dev": true
         },
         "ignore": {
-          "version": "5.1.9",
+          "version": "5.2.0",
           "bundled": true,
           "dev": true
         },
@@ -14557,7 +14557,7 @@
           }
         },
         "minimatch": {
-          "version": "3.0.4",
+          "version": "3.0.5",
           "bundled": true,
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.0.0",
+    "aws-cdk-lib": "2.12.0",
     "constructs": "10.0.5",
     "esbuild": "^0.16.0",
     "eslint": "^8",
@@ -72,7 +72,7 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.12.0",
     "constructs": "^10.0.5"
   },
   "keywords": [


### PR DESCRIPTION
BREAKING CHANGE: Versions of  `aws-cdk-lib` <= 2.11.0 depend on vulnerable packages and should not be used anymore. Please upgrade to a more recent version of `aws-cdk-lib`.