### PR TITLE
ci: auto-approve backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,3 +36,8 @@ pull_request_rules:
       - status-success=integ-python
       - status-success=integ-go
       - status-success=test-latest-versions
+defaults:
+  actions:
+    backport:
+      labels:
+        - auto-approve

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -137,6 +137,11 @@ const project = new awscdk.AwsCdkConstructLibrary({
   ],
 });
 
+// auto approve backports
+project.tryFindObjectFile('.mergify.yml')?.addOverride('defaults.actions.backport', {
+  labels: ['auto-approve'],
+});
+
 
 // setup integration tests
 new IntegrationTests(project, {


### PR DESCRIPTION
backports currently need manual approval, which is unnecessary since they have been approved already.