### PR TITLE
ci: allow PRs opened by mergify to be auto-approved

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'projen-builder[bot]' || github.event.pull_request.user.login == 'mrgrain')
+    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'projen-builder[bot]' || github.event.pull_request.user.login == 'mergify[bot]' || github.event.pull_request.user.login == 'mrgrain')
     steps:
       - uses: hmarr/auto-approve-action@v2.2.1
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -57,6 +57,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   autoApproveOptions: {
     allowedUsernames: [
       'projen-builder[bot]', // Bot account for upgrade PRs
+      'mergify[bot]', // Bot account for backports
       'mrgrain', // Auto-approve PRs of main maintainer
     ],
   },


### PR DESCRIPTION
Fixes backport PRs not bein auto-approved