### PR TITLE
fix: ts config option baseUrl has incorrect type

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -291,7 +291,7 @@ new TypeScriptSourceFile(project, 'src/esbuild-types.ts', {
       isExported: true,
       properties: [
         ['alwaysStrict', 'boolean'],
-        ['baseUrl', 'boolean'],
+        ['baseUrl', 'string'],
         ['experimentalDecorators', 'boolean'],
         ['importsNotUsedAsValues', "'remove' | 'preserve' | 'error'"],
         ['jsx', "'preserve' | 'react-native' | 'react' | 'react-jsx' | 'react-jsxdev'"],

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Security Policy
 
-See [SECURITY.md](https://github.com/mrgrain/cdk-esbuild/blob/main/SECURITY.md) on `main`.
+See [Security Policy](https://github.com/mrgrain/cdk-esbuild/security/policy).

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,3 @@
 # Supported Versions
 
-See [VERSIONS.md](https://github.com/mrgrain/cdk-esbuild/blob/main/VERSIONS.md) on `main`.
+See [VERSIONS.md](https://github.com/mrgrain/cdk-esbuild/blob/v5/VERSIONS.md) on `v5`.

--- a/src/esbuild-types.ts
+++ b/src/esbuild-types.ts
@@ -657,7 +657,7 @@ export let version: string;
 
 export interface CompilerOptions {
   readonly alwaysStrict?: boolean;
-  readonly baseUrl?: boolean;
+  readonly baseUrl?: string;
   readonly experimentalDecorators?: boolean;
   readonly importsNotUsedAsValues?: 'remove' | 'preserve' | 'error';
   readonly jsx?: 'preserve' | 'react-native' | 'react' | 'react-jsx' | 'react-jsxdev';


### PR DESCRIPTION
This bug was inherited from esbuild and fixed in later versions. Backporting the fix to v4.
