### PR TITLE
fix: cannot have multiple TypeScriptCode in the same scope

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -7,7 +7,7 @@ import {
 } from './asset';
 import { BundlerProps, EntryPoints } from './bundler';
 import { BuildOptions } from './esbuild-types';
-import { defaultPlatformProps } from './private/utils';
+import { defaultPlatformProps, uniqueAssetId } from './private/utils';
 
 export { CodeConfig } from 'aws-cdk-lib/aws-lambda';
 
@@ -89,7 +89,11 @@ export class TypeScriptCode extends Code {
   bind(scope: Construct): CodeConfig {
     // If the same AssetCode is used multiple times, retain only the first instantiation.
     if (!this.asset) {
-      this.asset = new TypeScriptAsset(scope, this.constructor.name, this.props);
+      this.asset = new TypeScriptAsset(
+        scope,
+        uniqueAssetId(scope, this.constructor.name),
+        this.props,
+      );
     } else if (Stack.of(this.asset) !== Stack.of(scope)) {
       throw new Error(
         `Asset is already associated with another stack '${

--- a/src/private/utils.ts
+++ b/src/private/utils.ts
@@ -1,3 +1,4 @@
+import { IConstruct } from 'constructs';
 import { BuildOptions, Platform, TransformOptions } from '../esbuild-types';
 
 export function isEsbuildError(error: unknown): boolean {
@@ -22,3 +23,16 @@ export function defaultPlatformProps(options?: BuildOptions | TransformOptions):
 
   return {};
 }
+
+const assetIds = new WeakMap<IConstruct, number>();
+export const uniqueAssetId = (scope: IConstruct, name: string) => {
+  const nextId = (assetIds.get(scope) ?? 0) + 1;
+  assetIds.set(scope, nextId);
+
+  // Only one asset per scope, skip the id
+  if (nextId === 1) {
+    return name;
+  }
+
+  return `${name}${nextId}`;
+};

--- a/src/source.ts
+++ b/src/source.ts
@@ -4,24 +4,12 @@ import {
   ISource,
   SourceConfig,
 } from 'aws-cdk-lib/aws-s3-deployment';
-import { Construct, IConstruct } from 'constructs';
+import { Construct } from 'constructs';
 import { TypeScriptAsset, TypeScriptAssetProps } from './asset';
 import { EntryPoints } from './bundler';
 import { TypeScriptCodeProps } from './code';
 import { BuildOptions } from './esbuild-types';
-
-const assetIds = new WeakMap<IConstruct, number>();
-const assetId = (scope: IConstruct, name: string) => {
-  const nextId = (assetIds.get(scope) ?? 0) + 1;
-  assetIds.set(scope, nextId);
-
-  // Only one asset per scope, skip the id
-  if (nextId === 1) {
-    return name;
-  }
-
-  return `${name}${nextId}`;
-};
+import { uniqueAssetId } from './private/utils';
 
 export interface TypeScriptSourceProps extends TypeScriptCodeProps {};
 
@@ -79,7 +67,7 @@ export class TypeScriptSource implements ISource {
     if (!this.asset) {
       this.asset = new TypeScriptAsset(
         scope,
-        assetId(scope, this.constructor.name),
+        uniqueAssetId(scope, this.constructor.name),
         this.props,
       );
     } else if (Stack.of(this.asset) !== Stack.of(scope)) {

--- a/test/code.test.ts
+++ b/test/code.test.ts
@@ -202,3 +202,20 @@ describe('Amazon CloudWatch Synthetics', () => {
     });
   });
 });
+
+describe('multiple Code in the same scope', () => {
+  it('does not throw', () => {
+    const stack = new Stack();
+
+    const codeOne = new TypeScriptCode('fixtures/handlers/ts-handler.ts', {
+      buildOptions: { absWorkingDir: resolve(__dirname) },
+    });
+
+    const codeTwo = new TypeScriptCode('fixtures/handlers/ts-handler.ts', {
+      buildOptions: { absWorkingDir: resolve(__dirname) },
+    });
+
+    codeOne.bind(stack);
+    codeTwo.bind(stack);
+  });
+});


### PR DESCRIPTION
Same as #1016 but for `TypeScriptCode` (not just `TypeScriptSource`).

This issue is unlikely to occur and was only triggered when `TypeScriptCode.bind()` was invoked directly.