### PR TITLE
chore: remove note on cloudwatch synthetics being alpha from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ new s3deploy.BucketDeployment(stack, "DeployWebsite", {
 
 Synthetics runs a canary to produce traffic to an application for monitoring purposes. Use `TypeScriptCode` as the `code` of a Canary test:
 
-> ℹ️ This feature depends on `@aws-cdk/aws-synthetics-alpha` which is in developer preview.
-> Please install the package using the respective tool of your language.
-> You may need to update your source code when upgrading to a newer version of this alpha package.
-
 ```ts
 const bundledCode = new TypeScriptCode("src/canary.ts", {
   buildOptions: {


### PR DESCRIPTION
[@aws-cdk/aws-synthetics-alpha](https://www.npmjs.com/package/@aws-cdk/aws-synthetics-alpha) is deprecated and cloudwatch synthetics is stable now.