### PR TITLE
fix(esbuild): always bundle packages on node

### DIFF
--- a/src/private/utils.ts
+++ b/src/private/utils.ts
@@ -16,9 +16,17 @@ export function nodeMajorVersion(): number {
 export function defaultPlatformProps(options?: BuildOptions | TransformOptions): {
   platform?: Platform;
   target?: string | string[];
+  packages?: any;
 } {
   if (!options?.platform || options?.platform === 'node') {
-    return { platform: 'node', target: 'node' + nodeMajorVersion() };
+    return {
+      platform: 'node',
+      target: 'node' + nodeMajorVersion(),
+
+      // Breaking change in esbuild v0.22.0 that is likely not desireable for this user base
+      // @see https://github.com/evanw/esbuild/commit/196dcad1954cdd462cd41ca6bd93ca528b15c0f8
+      packages: 'bundle',
+    };
   }
 
   return {};


### PR DESCRIPTION
A breaking change in esbuild v0.22.0 change the default bundling behavior for node packages from bundling packages to not bundling them.

This came out of nowhere and I'm not entirely sure how the dust is going to settle on this. However I believe this setting is likely not desirable for this user's of this package. Therefore I am proactively adjusting the default.

See https://github.com/evanw/esbuild/commit/196dcad1954cdd462cd41ca6bd93ca528b15c0f8

#1312