### PR TITLE
feat: enable trusted publishing for npm, pypi, and nuget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -102,8 +103,9 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       id-token: write
+      contents: read
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -135,7 +137,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
       - name: Update tags
         run: |-
@@ -153,6 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-java@v5
@@ -199,6 +202,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -231,8 +236,7 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-pypi
   release_nuget:
     name: Publish to NuGet Gallery
@@ -240,6 +244,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -272,14 +278,16 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: npx -p publib@latest publib-nuget
+          NUGET_TRUSTED_PUBLISHER: true
+          NUGET_USERNAME: mrgrain
+        run: npx -p github:cdklabs/publib#mrgrain/feat/nuget-trusted-publishing publib-nuget
   release_golang:
     name: Publish to GitHub Go Module Repository
     needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-import { awscdk, github, javascript, vscode } from 'projen';
+import { awscdk, github, javascript, JsonPatch, vscode } from 'projen';
 import { SourceFile } from 'ts-morph';
 import { StableReleases, TypeScriptSourceFile, WordmarkReadme } from './projenrc';
 import { IntegrationTests } from './projenrc/IntegrationTests';
@@ -93,9 +93,12 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
 
   // Release
+  releaseEnvironment: 'release',
+  npmTrustedPublishing: true,
   publishToPypi: {
     distName: 'mrgrain.cdk-esbuild',
     module: 'mrgrain.cdk_esbuild',
+    trustedPublishing: true,
   },
   publishToNuget: {
     dotNetNamespace: 'Mrgrain.CdkEsbuild',
@@ -331,8 +334,14 @@ new TypeScriptSourceFile(project, 'src/esbuild-types.ts', {
   },
 });
 
-// Use official github-app-token action
-project.github?.actions.set('tibdex/github-app-token', 'actions/create-github-app-token@v1');
+// TMP Nuget Trusted Publisher
+project.github?.tryFindWorkflow('release')?.file?.patch(
+  JsonPatch.add('/jobs/release_nuget/permissions/id-token', 'write'),
+  JsonPatch.remove('/jobs/release_nuget/steps/10/env/NUGET_API_KEY'),
+  JsonPatch.add('/jobs/release_nuget/steps/10/env/NUGET_TRUSTED_PUBLISHER', true),
+  JsonPatch.add('/jobs/release_nuget/steps/10/env/NUGET_USERNAME', 'mrgrain'),
+  JsonPatch.add('/jobs/release_nuget/steps/10/run', 'npx -p github:cdklabs/publib#mrgrain/feat/nuget-trusted-publishing publib-nuget'),
+);
 
 // Synth project
 project.synth();


### PR DESCRIPTION
This PR enables trusted publishing (OIDC authentication) for npm, PyPI, and NuGet package publishing, replacing the need for API tokens with secure GitHub Actions OIDC tokens.

## Changes

- Add `release` environment to all publishing jobs for enhanced security
- Enable npm trusted publishing via `NPM_TRUSTED_PUBLISHER` environment variable
- Enable PyPI trusted publishing via `PYPI_TRUSTED_PUBLISHER` environment variable  
- Enable NuGet trusted publishing with temporary publib branch (pending upstream merge)
- Add required `id-token: write` permissions for OIDC authentication
- Configure projen settings for trusted publishing support

## Benefits

- Enhanced security by eliminating long-lived API tokens
- Automatic token rotation and scoped permissions
- Reduced secret management overhead
- Compliance with modern security best practices

Fixes #