### PR TITLE
chore: upgrade npm release job to Node.js 24.x for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: 18.x
+          node-version: 24.x
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -334,7 +334,12 @@ new TypeScriptSourceFile(project, 'src/esbuild-types.ts', {
   },
 });
 
-// TMP Nuget Trusted Publisher
+// tmp: NPM Trusted Publishing needs a newer npm version
+project.github?.tryFindWorkflow('release')?.file?.patch(
+  JsonPatch.add('/jobs/release_npm/steps/0/with/node-version', '24.x'),
+);
+
+// tmp: Nuget Trusted Publishing while not in projen
 project.github?.tryFindWorkflow('release')?.file?.patch(
   JsonPatch.add('/jobs/release_nuget/permissions/id-token', 'write'),
   JsonPatch.remove('/jobs/release_nuget/steps/10/env/NUGET_API_KEY'),


### PR DESCRIPTION
Upgrades the Node.js version from 18.x to 24.x in the npm release job to meet the requirements for npm trusted publishing.

This change ensures compatibility with the newer npm trusted publishing workflow that requires a more recent Node.js version.

Fixes #