### PR TITLE
chore: update trusted publishing configuration for npm and nuget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,9 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
+      - uses: electron/npm-trusted-auth-action@v1.0.0
+        with:
+          package-name: "@mrgrain/cdk-esbuild"
       - name: Update tags
         run: |-
           version=`cat dist.old/version.txt`
@@ -146,7 +149,6 @@ jobs:
           npm dist-tag add @mrgrain/cdk-esbuild@$version cdk-v2
         env:
           NPM_REGISTRY: registry.npmjs.org
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     env:
       NPM_CONFIG_PROVENANCE: "true"
   release_maven:
@@ -278,9 +280,9 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          NUGET_TRUSTED_PUBLISHER: true
-          NUGET_USERNAME: mrgrain
-        run: npx -p github:cdklabs/publib#mrgrain/feat/nuget-trusted-publishing publib-nuget
+          NUGET_TRUSTED_PUBLISHER: "true"
+          NUGET_USERNAME: ${{ secrets.NUGET_USERNAME }}
+        run: npx -p publib@latest publib-nuget
   release_golang:
     name: Publish to GitHub Go Module Repository
     needs: release

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -96,11 +96,12 @@ const project = new awscdk.AwsCdkConstructLibrary({
   releaseEnvironment: 'release',
   npmTrustedPublishing: true,
   publishToPypi: {
+    trustedPublishing: true,
     distName: 'mrgrain.cdk-esbuild',
     module: 'mrgrain.cdk_esbuild',
-    trustedPublishing: true,
   },
   publishToNuget: {
+    trustedPublishing: true,
     dotNetNamespace: 'Mrgrain.CdkEsbuild',
     packageId: 'Mrgrain.CdkEsbuild',
     iconUrl: 'https://raw.githubusercontent.com/mrgrain/cdk-esbuild/main/images/logo.png',
@@ -337,15 +338,6 @@ new TypeScriptSourceFile(project, 'src/esbuild-types.ts', {
 // tmp: NPM Trusted Publishing needs a newer npm version
 project.github?.tryFindWorkflow('release')?.file?.patch(
   JsonPatch.add('/jobs/release_npm/steps/0/with/node-version', '24.x'),
-);
-
-// tmp: Nuget Trusted Publishing while not in projen
-project.github?.tryFindWorkflow('release')?.file?.patch(
-  JsonPatch.add('/jobs/release_nuget/permissions/id-token', 'write'),
-  JsonPatch.remove('/jobs/release_nuget/steps/10/env/NUGET_API_KEY'),
-  JsonPatch.add('/jobs/release_nuget/steps/10/env/NUGET_TRUSTED_PUBLISHER', true),
-  JsonPatch.add('/jobs/release_nuget/steps/10/env/NUGET_USERNAME', 'mrgrain'),
-  JsonPatch.add('/jobs/release_nuget/steps/10/run', 'npx -p github:cdklabs/publib#mrgrain/feat/nuget-trusted-publishing publib-nuget'),
 );
 
 // Synth project

--- a/projenrc/ReleaseBranches.ts
+++ b/projenrc/ReleaseBranches.ts
@@ -90,6 +90,12 @@ export class StableReleases {
 
       // Additional npm dist tags
       if (opts.npmDistTags) {
+        releaseWorkflow?.patch(JsonPatch.add('/jobs/release_npm/steps/-', {
+          uses: 'electron/npm-trusted-auth-action@v1.0.0',
+          with: {
+            'package-name': project.package.packageName,
+          },
+        }));
         releaseWorkflow?.patch(JsonPatch.add('/jobs/release_npm/steps/-', tagOnNpm(opts.npmDistTags)));
       }
 
@@ -120,7 +126,6 @@ export class StableReleases {
         ].concat(tags.map(tag => `npm dist-tag add ${project.package.packageName}@$version ${tag}`)).join('\n'),
         env: {
           NPM_REGISTRY: 'registry.npmjs.org',
-          NPM_TOKEN: '${{ secrets.NPM_TOKEN }}',
         },
       };
     };


### PR DESCRIPTION
Updates trusted publishing configuration:

- Enable trusted publishing for PyPI and NuGet in projen config
- Add npm-trusted-auth-action for npm publishing
- Remove manual NPM_TOKEN usage in favor of trusted publishing
- Update NuGet configuration to use latest publib version
- Clean up temporary patches now that trusted publishing is supported

This modernizes the publishing workflow to use OIDC authentication instead of long-lived tokens.