### PR TITLE
feat: add CloudFront Functions support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,8 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
-      - uses: electron/npm-trusted-auth-action@v1.0.0
+      - id: npm_oidc_token
+        uses: electron/npm-trusted-auth-action@v1.0.0
         with:
           package-name: "@mrgrain/cdk-esbuild"
       - name: Update tags
@@ -149,6 +150,7 @@ jobs:
           npm dist-tag add @mrgrain/cdk-esbuild@$version cdk-v2
         env:
           NPM_REGISTRY: registry.npmjs.org
+          NPM_TOKEN: ${{ steps.npm_oidc_token.outputs.token }}
     env:
       NPM_CONFIG_PROVENANCE: "true"
   release_maven:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,7 @@ jobs:
           echo $version
           npm dist-tag add @mrgrain/cdk-esbuild@$version cdk-v2
         env:
-          NPM_REGISTRY: registry.npmjs.org
-          NPM_TOKEN: ${{ steps.npm_oidc_token.outputs.token }}
+          NPM_TOKEN: ${{ steps.npm_oidc_token.outputs.npm-token }}
     env:
       NPM_CONFIG_PROVENANCE: "true"
   release_maven:

--- a/API.md
+++ b/API.md
@@ -1241,6 +1241,150 @@ Instead use only relative paths and avoid `..`.
 
 ---
 
+### CloudFrontFunctionCodeProps <a name="CloudFrontFunctionCodeProps" id="@mrgrain/cdk-esbuild.CloudFrontFunctionCodeProps"></a>
+
+Properties for CloudFront Function TypeScript code.
+
+#### Initializer <a name="Initializer" id="@mrgrain/cdk-esbuild.CloudFrontFunctionCodeProps.Initializer"></a>
+
+```typescript
+import { CloudFrontFunctionCodeProps } from '@mrgrain/cdk-esbuild'
+
+const cloudFrontFunctionCodeProps: CloudFrontFunctionCodeProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionCodeProps.property.buildOptions">buildOptions</a></code> | <code><a href="#@mrgrain/cdk-esbuild.BuildOptions">BuildOptions</a></code> | Build options passed on to esbuild. Please refer to the esbuild Build API docs for details. |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionCodeProps.property.buildProvider">buildProvider</a></code> | <code><a href="#@mrgrain/cdk-esbuild.IBuildProvider">IBuildProvider</a></code> | The esbuild Build API implementation to be used. |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionCodeProps.property.runtime">runtime</a></code> | <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime">CloudFrontFunctionRuntime</a></code> | CloudFront Functions JavaScript runtime environment version to build for. |
+
+---
+
+##### `buildOptions`<sup>Optional</sup> <a name="buildOptions" id="@mrgrain/cdk-esbuild.CloudFrontFunctionCodeProps.property.buildOptions"></a>
+
+```typescript
+public readonly buildOptions: BuildOptions;
+```
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.BuildOptions">BuildOptions</a>
+
+Build options passed on to esbuild. Please refer to the esbuild Build API docs for details.
+
+* `buildOptions.outdir: string`
+The actual path for the output directory is defined by CDK. However setting this option allows to write files into a subdirectory. \
+For example `{ outdir: 'js' }` will create an asset with a single directory called `js`, which contains all built files. This approach can be useful for static website deployments, where JavaScript code should be placed into a subdirectory. \
+*Cannot be used together with `outfile`*.
+* `buildOptions.outfile: string`
+Relative path to a file inside the CDK asset output directory.
+For example `{ outfile: 'js/index.js' }` will create an asset with a single directory called `js`, which contains a single file `index.js`. This can be useful to rename the entry point. \
+*Cannot be used with multiple entryPoints or together with `outdir`.*
+* `buildOptions.absWorkingDir: string`
+Absolute path to the [esbuild working directory](https://esbuild.github.io/api/#working-directory) and defaults to the [current working directory](https://en.wikipedia.org/wiki/Working_directory). \
+If paths cannot be found, a good starting point is to look at the concatenation of `absWorkingDir + entryPoint`. It must always be a valid absolute path pointing to the entry point. When needed, the probably easiest way to set absWorkingDir is to use a combination of `resolve` and `__dirname` (see "Library authors" section in the documentation).
+
+> [https://esbuild.github.io/api/#build-api](https://esbuild.github.io/api/#build-api)
+
+---
+
+##### `buildProvider`<sup>Optional</sup> <a name="buildProvider" id="@mrgrain/cdk-esbuild.CloudFrontFunctionCodeProps.property.buildProvider"></a>
+
+```typescript
+public readonly buildProvider: IBuildProvider;
+```
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.IBuildProvider">IBuildProvider</a>
+- *Default:* new EsbuildProvider()
+
+The esbuild Build API implementation to be used.
+
+Configure the default `EsbuildProvider` for more options or
+provide a custom `IBuildProvider` as an escape hatch.
+
+---
+
+##### `runtime`<sup>Optional</sup> <a name="runtime" id="@mrgrain/cdk-esbuild.CloudFrontFunctionCodeProps.property.runtime"></a>
+
+```typescript
+public readonly runtime: CloudFrontFunctionRuntime;
+```
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime">CloudFrontFunctionRuntime</a>
+- *Default:* CloudFrontFunctionRuntime.JS_1_0
+
+CloudFront Functions JavaScript runtime environment version to build for.
+
+---
+
+### CloudFrontFunctionInlineCodeProps <a name="CloudFrontFunctionInlineCodeProps" id="@mrgrain/cdk-esbuild.CloudFrontFunctionInlineCodeProps"></a>
+
+Properties for CloudFront Function inline code.
+
+#### Initializer <a name="Initializer" id="@mrgrain/cdk-esbuild.CloudFrontFunctionInlineCodeProps.Initializer"></a>
+
+```typescript
+import { CloudFrontFunctionInlineCodeProps } from '@mrgrain/cdk-esbuild'
+
+const cloudFrontFunctionInlineCodeProps: CloudFrontFunctionInlineCodeProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionInlineCodeProps.property.transformOptions">transformOptions</a></code> | <code><a href="#@mrgrain/cdk-esbuild.TransformOptions">TransformOptions</a></code> | Transform options passed on to esbuild. |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionInlineCodeProps.property.transformProvider">transformProvider</a></code> | <code><a href="#@mrgrain/cdk-esbuild.ITransformProvider">ITransformProvider</a></code> | The esbuild Transform API implementation to be used. |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionInlineCodeProps.property.runtime">runtime</a></code> | <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime">CloudFrontFunctionRuntime</a></code> | CloudFront Functions JavaScript runtime environment version to build for. |
+
+---
+
+##### `transformOptions`<sup>Optional</sup> <a name="transformOptions" id="@mrgrain/cdk-esbuild.CloudFrontFunctionInlineCodeProps.property.transformOptions"></a>
+
+```typescript
+public readonly transformOptions: TransformOptions;
+```
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.TransformOptions">TransformOptions</a>
+
+Transform options passed on to esbuild.
+
+Please refer to the esbuild Transform API docs for details.
+
+> [https://esbuild.github.io/api/#transform-api](https://esbuild.github.io/api/#transform-api)
+
+---
+
+##### `transformProvider`<sup>Optional</sup> <a name="transformProvider" id="@mrgrain/cdk-esbuild.CloudFrontFunctionInlineCodeProps.property.transformProvider"></a>
+
+```typescript
+public readonly transformProvider: ITransformProvider;
+```
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.ITransformProvider">ITransformProvider</a>
+- *Default:* new DefaultEsbuildProvider()
+
+The esbuild Transform API implementation to be used.
+
+Configure the default `EsbuildProvider` for more options or
+provide a custom `ITransformProvider` as an escape hatch.
+
+---
+
+##### `runtime`<sup>Optional</sup> <a name="runtime" id="@mrgrain/cdk-esbuild.CloudFrontFunctionInlineCodeProps.property.runtime"></a>
+
+```typescript
+public readonly runtime: CloudFrontFunctionRuntime;
+```
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime">CloudFrontFunctionRuntime</a>
+- *Default:* CloudFrontFunctionRuntime.JS_1_0
+
+CloudFront Functions JavaScript runtime environment version to build for.
+
+---
+
 ### CodeConfig <a name="CodeConfig" id="@mrgrain/cdk-esbuild.CodeConfig"></a>
 
 Result of binding `Code` into a `Function`.
@@ -3957,6 +4101,136 @@ Defaults to a hash of all files in the resulting bundle.
 ---
 
 ## Classes <a name="Classes" id="Classes"></a>
+
+### CloudFrontFunctionRuntime <a name="CloudFrontFunctionRuntime" id="@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime"></a>
+
+CloudFront Functions JavaScript runtime environment version.
+
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime.property.value">value</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `value`<sup>Required</sup> <a name="value" id="@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime.property.value"></a>
+
+```typescript
+public readonly value: string;
+```
+
+- *Type:* string
+
+---
+
+#### Constants <a name="Constants" id="Constants"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime.property.JS_1_0">JS_1_0</a></code> | <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime">CloudFrontFunctionRuntime</a></code> | cloudfront-js-1.0 - limited ES6 support, no const/let, no async/await. |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime.property.JS_2_0">JS_2_0</a></code> | <code><a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime">CloudFrontFunctionRuntime</a></code> | cloudfront-js-2.0 - enhanced ES6 support, const/let and async/await supported. |
+
+---
+
+##### `JS_1_0`<sup>Required</sup> <a name="JS_1_0" id="@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime.property.JS_1_0"></a>
+
+```typescript
+public readonly JS_1_0: CloudFrontFunctionRuntime;
+```
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime">CloudFrontFunctionRuntime</a>
+
+cloudfront-js-1.0 - limited ES6 support, no const/let, no async/await.
+
+---
+
+##### `JS_2_0`<sup>Required</sup> <a name="JS_2_0" id="@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime.property.JS_2_0"></a>
+
+```typescript
+public readonly JS_2_0: CloudFrontFunctionRuntime;
+```
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionRuntime">CloudFrontFunctionRuntime</a>
+
+cloudfront-js-2.0 - enhanced ES6 support, const/let and async/await supported.
+
+---
+
+### CloudFrontTypeScriptCode <a name="CloudFrontTypeScriptCode" id="@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode"></a>
+
+TypeScript code for CloudFront Functions.
+
+#### Initializers <a name="Initializers" id="@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode.Initializer"></a>
+
+```typescript
+import { CloudFrontTypeScriptCode } from '@mrgrain/cdk-esbuild'
+
+new CloudFrontTypeScriptCode()
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode.fromFile">fromFile</a></code> | Create CloudFront Function code from a TypeScript file. |
+| <code><a href="#@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode.fromInline">fromInline</a></code> | Create CloudFront Function code from inline TypeScript code. |
+
+---
+
+##### `fromFile` <a name="fromFile" id="@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode.fromFile"></a>
+
+```typescript
+import { CloudFrontTypeScriptCode } from '@mrgrain/cdk-esbuild'
+
+CloudFrontTypeScriptCode.fromFile(entryPoint: string, props?: CloudFrontFunctionCodeProps)
+```
+
+Create CloudFront Function code from a TypeScript file.
+
+###### `entryPoint`<sup>Required</sup> <a name="entryPoint" id="@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode.fromFile.parameter.entryPoint"></a>
+
+- *Type:* string
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode.fromFile.parameter.props"></a>
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionCodeProps">CloudFrontFunctionCodeProps</a>
+
+---
+
+##### `fromInline` <a name="fromInline" id="@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode.fromInline"></a>
+
+```typescript
+import { CloudFrontTypeScriptCode } from '@mrgrain/cdk-esbuild'
+
+CloudFrontTypeScriptCode.fromInline(code: string, props?: CloudFrontFunctionInlineCodeProps)
+```
+
+Create CloudFront Function code from inline TypeScript code.
+
+###### `code`<sup>Required</sup> <a name="code" id="@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode.fromInline.parameter.code"></a>
+
+- *Type:* string
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@mrgrain/cdk-esbuild.CloudFrontTypeScriptCode.fromInline.parameter.props"></a>
+
+- *Type:* <a href="#@mrgrain/cdk-esbuild.CloudFrontFunctionInlineCodeProps">CloudFrontFunctionInlineCodeProps</a>
+
+---
+
+
 
 ### EsbuildBundler <a name="EsbuildBundler" id="@mrgrain/cdk-esbuild.EsbuildBundler"></a>
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ new s3deploy.BucketDeployment(stack, "DeployWebsite", {
 });
 ```
 
+### Amazon CloudFront: Functions
+
+Use `CloudFrontTypeScriptCode` as the `code` of a [CloudFront Function](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html):
+
+```ts fixture=local
+const functionCode = CloudFrontTypeScriptCode.fromFile("src/function.ts", {
+  runtime: cloudfront.FunctionRuntime.JS_2_0,
+});
+
+const cfFunction = new cloudfront.Function(stack, "MyFunction", {
+  code: functionCode,
+  runtime: cloudfront.FunctionRuntime.JS_2_0,
+});
+```
+
 ### Amazon CloudWatch Synthetics: Canary monitoring
 
 > 💡 See [Monitored Website (TypeScript)](examples/typescript/website) for a working example of a deployed and monitored website.

--- a/projenrc/ReleaseBranches.ts
+++ b/projenrc/ReleaseBranches.ts
@@ -126,8 +126,7 @@ export class StableReleases {
           'echo $version',
         ].concat(tags.map(tag => `npm dist-tag add ${project.package.packageName}@$version ${tag}`)).join('\n'),
         env: {
-          NPM_REGISTRY: 'registry.npmjs.org',
-          NPM_TOKEN: '${{ steps.npm_oidc_token.outputs.token }}',
+          NPM_TOKEN: '${{ steps.npm_oidc_token.outputs.npm-token }}',
         },
       };
     };

--- a/projenrc/ReleaseBranches.ts
+++ b/projenrc/ReleaseBranches.ts
@@ -91,6 +91,7 @@ export class StableReleases {
       // Additional npm dist tags
       if (opts.npmDistTags) {
         releaseWorkflow?.patch(JsonPatch.add('/jobs/release_npm/steps/-', {
+          id: 'npm_oidc_token',
           uses: 'electron/npm-trusted-auth-action@v1.0.0',
           with: {
             'package-name': project.package.packageName,
@@ -126,6 +127,7 @@ export class StableReleases {
         ].concat(tags.map(tag => `npm dist-tag add ${project.package.packageName}@$version ${tag}`)).join('\n'),
         env: {
           NPM_REGISTRY: 'registry.npmjs.org',
+          NPM_TOKEN: '${{ steps.npm_oidc_token.outputs.token }}',
         },
       };
     };

--- a/rosetta/default.ts-fixture
+++ b/rosetta/default.ts-fixture
@@ -1,9 +1,10 @@
 import * as path from 'node:path';
-import * as cdk from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib/core';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
 import * as synthetics from "aws-cdk-lib/aws-synthetics";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import { 
     BuildOptions,
     EsbuildSource,

--- a/rosetta/local.ts-fixture
+++ b/rosetta/local.ts-fixture
@@ -1,0 +1,12 @@
+
+import * as cdk from 'aws-cdk-lib/core';
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+
+const stack = new cdk.Stack();
+
+declare class CloudFrontTypeScriptCode {
+    static fromFile(entryPoint: string, props?: object): cloudfront.FunctionCode;
+    static fromInline(code: string, props?: object): cloudfront.FunctionCode;
+}
+
+/// here

--- a/rosetta/local.ts-fixture
+++ b/rosetta/local.ts-fixture
@@ -1,4 +1,3 @@
-
 import * as cdk from 'aws-cdk-lib/core';
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 

--- a/src/cloudfront-function-code.ts
+++ b/src/cloudfront-function-code.ts
@@ -1,0 +1,247 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FunctionCode } from 'aws-cdk-lib/aws-cloudfront';
+import { EsbuildBundler } from './bundler';
+import { BuildOptions } from './esbuild-types';
+import { TransformerProps } from './inline-code';
+import { EsbuildProvider, IBuildProvider, ProviderTransformOptions } from './provider';
+
+/**
+ * CloudFront Functions JavaScript runtime environment version.
+ *
+ * @stability stable
+ */
+export class CloudFrontFunctionRuntime {
+  public readonly value: string;
+
+  /**
+   * cloudfront-js-1.0 - limited ES6 support, no const/let, no async/await
+   */
+  public static readonly JS_1_0 = new CloudFrontFunctionRuntime('cloudfront-js-1.0');
+
+  /**
+   * cloudfront-js-2.0 - enhanced ES6 support, const/let and async/await supported
+   */
+  public static readonly JS_2_0 = new CloudFrontFunctionRuntime('cloudfront-js-2.0');
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+}
+
+/**
+ * Properties for CloudFront Function TypeScript code.
+ *
+ * @stability stable
+ */
+export interface CloudFrontFunctionCodeProps {
+  /**
+   * CloudFront Functions JavaScript runtime environment version to build for.
+   *
+   * @default CloudFrontFunctionRuntime.JS_1_0
+   */
+  readonly runtime?: CloudFrontFunctionRuntime;
+
+  /**
+   * Build options passed on to esbuild. Please refer to the esbuild Build API docs for details.
+   *
+   * * `buildOptions.outdir: string`
+   * The actual path for the output directory is defined by CDK. However setting this option allows to write files into a subdirectory. \
+   * For example `{ outdir: 'js' }` will create an asset with a single directory called `js`, which contains all built files. This approach can be useful for static website deployments, where JavaScript code should be placed into a subdirectory. \
+   * *Cannot be used together with `outfile`*.
+   * * `buildOptions.outfile: string`
+   * Relative path to a file inside the CDK asset output directory.
+   * For example `{ outfile: 'js/index.js' }` will create an asset with a single directory called `js`, which contains a single file `index.js`. This can be useful to rename the entry point. \
+   * *Cannot be used with multiple entryPoints or together with `outdir`.*
+   * * `buildOptions.absWorkingDir: string`
+   * Absolute path to the [esbuild working directory](https://esbuild.github.io/api/#working-directory) and defaults to the [current working directory](https://en.wikipedia.org/wiki/Working_directory). \
+   * If paths cannot be found, a good starting point is to look at the concatenation of `absWorkingDir + entryPoint`. It must always be a valid absolute path pointing to the entry point. When needed, the probably easiest way to set absWorkingDir is to use a combination of `resolve` and `__dirname` (see "Library authors" section in the documentation).
+   *
+   * @see https://esbuild.github.io/api/#build-api
+   * @stability stable
+   */
+  readonly buildOptions?: BuildOptions;
+
+  /**
+   * The esbuild Build API implementation to be used.
+   *
+   * Configure the default `EsbuildProvider` for more options or
+   * provide a custom `IBuildProvider` as an escape hatch.
+   *
+   * @stability stable
+   *
+   * @default new EsbuildProvider()
+   */
+  readonly buildProvider?: IBuildProvider;
+}
+/**
+ * Properties for CloudFront Function inline code.
+ *
+ * @stability stable
+ */
+export interface CloudFrontFunctionInlineCodeProps extends TransformerProps {
+  /**
+   * CloudFront Functions JavaScript runtime environment version to build for.
+   *
+   * @default CloudFrontFunctionRuntime.JS_1_0
+   */
+  readonly runtime?: CloudFrontFunctionRuntime;
+}
+
+
+/**
+ * TypeScript code for CloudFront Functions.
+ *
+ * @stability stable
+ */
+export class CloudFrontTypeScriptCode {
+  /**
+   * Create CloudFront Function code from a TypeScript file.
+   */
+  static fromFile(entryPoint: string, props: CloudFrontFunctionCodeProps = {}): FunctionCode {
+    return new EsbuildFunctionCode(entryPoint, props);
+  }
+
+  /**
+   * Create CloudFront Function code from inline TypeScript code.
+   */
+  static fromInline(code: string, props: CloudFrontFunctionInlineCodeProps = {}): FunctionCode {
+    return new InlineEsbuildFunctionCode(code, props);
+  }
+}
+
+/**
+ * @internal
+ */
+class EsbuildFunctionCode extends FunctionCode {
+  private readonly bundler: EsbuildBundler;
+  private bundledCode?: string;
+
+  constructor(entryPoint: string, props: CloudFrontFunctionCodeProps) {
+    super();
+
+    const runtimeVersion = props.runtime ?? CloudFrontFunctionRuntime.JS_1_0;
+
+    const buildOptions: BuildOptions = {
+      // defaults
+      treeShaking: true,
+      bundle: true,
+      // custom
+      ...props.buildOptions,
+      // forced
+      outfile: 'handler.js',
+      format: 'esm',
+      target: 'es5',
+      platform: 'neutral',
+      ...minifyOptions(props.buildOptions?.minify),
+      supported: {
+        ...props.buildOptions?.supported,
+        ...getSupportedFeatures(runtimeVersion),
+      },
+    };
+
+    this.bundler = new EsbuildBundler(entryPoint, {
+      ...props,
+      buildOptions,
+    });
+  }
+
+  render(): string {
+    if (!this.bundledCode) {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-function-'));
+
+      try {
+        const success = this.bundler.local.tryBundle(tempDir, this.bundler);
+        if (!success) {
+          throw new Error('Failed to bundle CloudFront Function code');
+        }
+        this.bundledCode = fs.readFileSync(path.join(tempDir, 'handler.js'), 'utf8');
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
+    return this.bundledCode!;
+  }
+}
+
+/**
+ * @internal
+ */
+class InlineEsbuildFunctionCode extends FunctionCode {
+  private readonly code: string;
+  private readonly props: CloudFrontFunctionInlineCodeProps;
+  private bundledCode?: string;
+
+  constructor(code: string, props: CloudFrontFunctionInlineCodeProps) {
+    super();
+    this.code = code;
+    this.props = props;
+  }
+
+  render(): string {
+    if (!this.bundledCode) {
+      const provider = this.props.transformProvider ?? EsbuildProvider.defaultTransformationProvider();
+      const runtimeVersion = this.props.runtime ?? CloudFrontFunctionRuntime.JS_1_0;
+
+      const transformOptions: ProviderTransformOptions = {
+        // defaults
+        treeShaking: true,
+        // custom
+        ...this.props.transformOptions,
+        // forced
+        format: 'esm',
+        target: 'es5',
+        platform: 'neutral',
+        ...minifyOptions(this.props.transformOptions?.minify),
+        supported: {
+          ...this.props.transformOptions?.supported,
+          ...getSupportedFeatures(runtimeVersion),
+        },
+      };
+
+      this.bundledCode = provider.transformSync(this.code, transformOptions);
+    }
+    return this.bundledCode!;
+  }
+}
+
+/**
+ * Get minify options.
+ */
+function minifyOptions(minify: boolean = true) {
+  if (!minify) {
+    return {
+      minify: false,
+      minifyWhitespace: false,
+      minifySyntax: false,
+      minifyIdentifiers: false,
+
+    };
+  }
+
+  return {
+    minify: false,
+    minifyWhitespace: true,
+    minifySyntax: true,
+    minifyIdentifiers: false,
+  };
+}
+
+
+/**
+ * Get supported features for CloudFront Functions runtime version.
+ */
+function getSupportedFeatures(runtimeVersion: CloudFrontFunctionRuntime) {
+  const isV2 = runtimeVersion.value === CloudFrontFunctionRuntime.JS_2_0.value;
+
+  return {
+    'const-and-let': isV2,
+    'exponent-operator': true,
+    'template-literal': true,
+    'arrow': true,
+    'rest-argument': true,
+    'regexp-named-capture-groups': true,
+    'async-await': isV2,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,13 @@ export {
 } from './bundler';
 
 export {
+  CloudFrontFunctionRuntime,
+  CloudFrontFunctionCodeProps,
+  CloudFrontFunctionInlineCodeProps,
+  CloudFrontTypeScriptCode,
+} from './cloudfront-function-code';
+
+export {
   CodeConfig,
   TypeScriptCode,
   TypeScriptCodeProps,

--- a/test/cloudfront-function-code.test.ts
+++ b/test/cloudfront-function-code.test.ts
@@ -1,0 +1,102 @@
+import { App, Stack } from 'aws-cdk-lib';
+import { Function as CloudFrontFunction } from 'aws-cdk-lib/aws-cloudfront';
+import { CloudFrontTypeScriptCode, CloudFrontFunctionRuntime } from '../src';
+
+describe('CloudFrontTypeScriptCode', () => {
+  let app: App;
+  let stack: Stack;
+
+  beforeEach(() => {
+    app = new App();
+    stack = new Stack(app, 'TestStack');
+  });
+
+  describe('fromFile', () => {
+    test('creates CloudFront function with TypeScript code from file', () => {
+      const code = CloudFrontTypeScriptCode.fromFile('test/fixtures/handlers/cf-handler.ts');
+
+      const fn = new CloudFrontFunction(stack, 'TestFunction', {
+        code,
+      });
+
+      expect(fn.functionName).toBeDefined();
+    });
+
+    test('applies CloudFront-specific build options', () => {
+      const code = CloudFrontTypeScriptCode.fromFile('test/fixtures/handlers/cf-handler.ts', {
+        buildOptions: {
+          define: { 'process.env.NODE_ENV': '"production"' },
+        },
+      });
+
+      const bundler = (code as any).bundler;
+      const buildOptions = (bundler as any).props.buildOptions;
+
+      expect(buildOptions.format).toBe('esm');
+      expect(buildOptions.target).toBe('es5');
+      expect(buildOptions.platform).toBe('neutral');
+      expect(buildOptions.minify).toBe(false);
+      expect(buildOptions.minifyWhitespace).toBe(true);
+      expect(buildOptions.minifySyntax).toBe(true);
+      expect(buildOptions.minifyIdentifiers).toBe(false);
+      expect(buildOptions.bundle).toBe(true);
+      expect(buildOptions.define).toEqual({ 'process.env.NODE_ENV': '"production"' });
+    });
+
+    test('renders bundled code', () => {
+      const code = CloudFrontTypeScriptCode.fromFile('test/fixtures/handlers/cf-handler.ts');
+
+      const bundledCode = code.render();
+      expect(typeof bundledCode).toBe('string');
+      expect(bundledCode.trim().length).toBeGreaterThan(0);
+      expect(bundledCode).toContain('function');
+    });
+  });
+
+  describe('runtime version differences', () => {
+    test('V1 runtime rejects const/let', () => {
+      const code = CloudFrontTypeScriptCode.fromInline('const x = 42; console.log(x);', {
+        runtime: CloudFrontFunctionRuntime.JS_1_0,
+      });
+
+      expect(() => code.render()).toThrow();
+    });
+
+    test('V1 runtime rejects async/await', () => {
+      const code = CloudFrontTypeScriptCode.fromInline('async function test() { await Promise.resolve(); }', {
+        runtime: CloudFrontFunctionRuntime.JS_1_0,
+      });
+
+      expect(() => code.render()).toThrow();
+    });
+
+    test('V2 runtime accepts const/let', () => {
+      const code = CloudFrontTypeScriptCode.fromInline('const x = 42; console.log(x);', {
+        runtime: CloudFrontFunctionRuntime.JS_2_0,
+      });
+
+      const result = code.render();
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('fromInline', () => {
+    test('creates CloudFront function with inline TypeScript code', () => {
+      const code = CloudFrontTypeScriptCode.fromInline('console.log("Hello CloudFront");');
+
+      const fn = new CloudFrontFunction(stack, 'TestFunction', {
+        code,
+      });
+
+      expect(fn.functionName).toBeDefined();
+    });
+
+    test('renders transformed inline code', () => {
+      const code = CloudFrontTypeScriptCode.fromInline('var x = 42; console.log(x);');
+
+      const renderedCode = code.render();
+      expect(typeof renderedCode).toBe('string');
+      expect(renderedCode.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/test/fixtures/handlers/cf-handler.ts
+++ b/test/fixtures/handlers/cf-handler.ts
@@ -1,0 +1,6 @@
+export function handler(event: any) {
+  return {
+    statusCode: 200,
+    statusDescription: 'OK',
+  };
+}


### PR DESCRIPTION
Implements CloudFront Functions support as requested in #102.

## Changes
- Add CloudFrontTypeScriptCode class with fromFile() and fromInline() static methods
- Support for CloudFront Functions runtime versions (JS_1_0, JS_2_0) 
- Proper esbuild configuration based on CloudFront Functions requirements:
  - ESM format, ES5 target, neutral platform
  - Minification with identifiers preserved
  - Runtime-specific supported features (const/let, async/await for v2)

## Usage
```typescript
// File-based
const code = CloudFrontTypeScriptCode.fromFile('src/function.ts', {
  runtime: cloudfront.FunctionRuntime.JS_2_0,
});

// Inline
const code = CloudFrontTypeScriptCode.fromInline('console.log("Hello");', {
  runtime: cloudfront.FunctionRuntime.JS_2_0,
});

new cloudfront.Function(this, 'MyFunction', {
  code,
  runtime: cloudfront.FunctionRuntime.JS_2_0,
});
```

Closes #102