### PR TITLE
chore(ci): correct GitHub app private key secret

### DIFF
--- a/.github/workflows/self-mutation.yml
+++ b/.github/workflows/self-mutation.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5
         with:
           app-id: ${{ secrets.PROJEN_APP_ID }}
-          private-key: ${{ secrets.PROJEN_APP_ID }}
+          private-key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
       - name: Checkout PR
         if: steps.download_patch.outcome == 'success'
         uses: actions/checkout@v5

--- a/projenrc/SelfMutationOnForks.ts
+++ b/projenrc/SelfMutationOnForks.ts
@@ -45,7 +45,7 @@ export class SelfMutationOnForks {
           uses: 'actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5',
           with: {
             'app-id': '${{ secrets.PROJEN_APP_ID }}',
-            'private-key': '${{ secrets.PROJEN_APP_ID }}',
+            'private-key': '${{ secrets.PROJEN_APP_PRIVATE_KEY }}',
           },
         },
         {

--- a/src/cloudfront-function-code.ts
+++ b/src/cloudfront-function-code.ts
@@ -209,7 +209,7 @@ class InlineEsbuildFunctionCode extends FunctionCode {
 /**
  * Get minify options.
  */
-function minifyOptions(minify: boolean = true) {
+function minifyOptions(minify: boolean = false) {
   if (!minify) {
     return {
       minify: false,

--- a/src/cloudfront-function-code.ts
+++ b/src/cloudfront-function-code.ts
@@ -209,7 +209,7 @@ class InlineEsbuildFunctionCode extends FunctionCode {
 /**
  * Get minify options.
  */
-function minifyOptions(minify: boolean = false) {
+function minifyOptions(minify: boolean = true) {
   if (!minify) {
     return {
       minify: false,


### PR DESCRIPTION
**GitHub App Secret Fix**: Corrects the incorrect secret reference in the self-mutation workflow. The workflow was referencing `PROJEN_APP_ID` for the private key instead of the correct `PROJEN_APP_PRIVATE_KEY` secret.