### PR TITLE
fix(cloudfront-function): change default minify to false

### DIFF
--- a/src/cloudfront-function-code.ts
+++ b/src/cloudfront-function-code.ts
@@ -209,7 +209,7 @@ class InlineEsbuildFunctionCode extends FunctionCode {
 /**
  * Get minify options.
  */
-function minifyOptions(minify: boolean = true) {
+function minifyOptions(minify: boolean = false) {
   if (!minify) {
     return {
       minify: false,

--- a/src/cloudfront-function-code.ts
+++ b/src/cloudfront-function-code.ts
@@ -208,6 +208,9 @@ class InlineEsbuildFunctionCode extends FunctionCode {
 
 /**
  * Get minify options.
+ *
+ * Defaults to false to match esbuild's default behavior and maintain consistency
+ * with other constructs in this package (TypeScriptCode, etc.).
  */
 function minifyOptions(minify: boolean = false) {
   if (!minify) {

--- a/test/cloudfront-function-code.test.ts
+++ b/test/cloudfront-function-code.test.ts
@@ -36,11 +36,20 @@ describe('CloudFrontTypeScriptCode', () => {
       expect(buildOptions.target).toBe('es5');
       expect(buildOptions.platform).toBe('neutral');
       expect(buildOptions.minify).toBe(false);
-      expect(buildOptions.minifyWhitespace).toBe(true);
-      expect(buildOptions.minifySyntax).toBe(true);
+      expect(buildOptions.minifyWhitespace).toBe(false);
+      expect(buildOptions.minifySyntax).toBe(false);
       expect(buildOptions.minifyIdentifiers).toBe(false);
       expect(buildOptions.bundle).toBe(true);
       expect(buildOptions.define).toEqual({ 'process.env.NODE_ENV': '"production"' });
+    });
+
+    test('defaults minify to false when no options provided', () => {
+      const code = CloudFrontTypeScriptCode.fromFile('test/fixtures/handlers/cf-handler.ts');
+
+      const bundler = (code as any).bundler;
+      const buildOptions = (bundler as any).props.buildOptions;
+
+      expect(buildOptions.minify).toBe(false);
     });
 
     test('renders bundled code', () => {


### PR DESCRIPTION
Changes the default minify parameter from true to false in the minifyOptions function for CloudFront functions.

This change aligns CloudFront function behavior with:
- esbuild's default behavior (minify: false)
- Other constructs in this package (TypeScriptCode, TypeScriptSource, etc.)

Previously, CloudFront functions were the only construct that defaulted to minification, which was inconsistent with the rest of the package and esbuild itself.

Fixes #