### PR TITLE
ci: disable npm dist-tag functionality due to trusted publisher limitations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,17 +139,6 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
-      - id: npm_oidc_token
-        uses: electron/npm-trusted-auth-action@v1.0.0
-        with:
-          package-name: "@mrgrain/cdk-esbuild"
-      - name: Update tags
-        run: |-
-          version=`cat dist.old/version.txt`
-          echo $version
-          npm dist-tag add @mrgrain/cdk-esbuild@$version cdk-v2
-        env:
-          NPM_TOKEN: ${{ steps.npm_oidc_token.outputs.npm-token }}
     env:
       NPM_CONFIG_PROVENANCE: "true"
   release_maven:

--- a/projenrc/ReleaseBranches.ts
+++ b/projenrc/ReleaseBranches.ts
@@ -90,14 +90,16 @@ export class StableReleases {
 
       // Additional npm dist tags
       if (opts.npmDistTags) {
-        releaseWorkflow?.patch(JsonPatch.add('/jobs/release_npm/steps/-', {
-          id: 'npm_oidc_token',
-          uses: 'electron/npm-trusted-auth-action@v1.0.0',
-          with: {
-            'package-name': project.package.packageName,
-          },
-        }));
-        releaseWorkflow?.patch(JsonPatch.add('/jobs/release_npm/steps/-', tagOnNpm(opts.npmDistTags)));
+        // @todo: revert once `npm dist-tag add` is supported by trusted publishers
+        tagOnNpm(opts.npmDistTags);
+        // releaseWorkflow?.patch(JsonPatch.add('/jobs/release_npm/steps/-', {
+        //   id: 'npm_oidc_token',
+        //   uses: 'electron/npm-trusted-auth-action@v1.0.0',
+        //   with: {
+        //     'package-name': project.package.packageName,
+        //   },
+        // }));
+        // releaseWorkflow?.patch(JsonPatch.add('/jobs/release_npm/steps/-', tagOnNpm(opts.npmDistTags)));
       }
 
       // Go branch


### PR DESCRIPTION
Temporarily disables npm dist-tag functionality in the release workflow due to limitations with trusted publishers.

The `npm dist-tag add` command is not currently supported by npm's trusted publisher authentication, so this change comments out the related workflow steps and adds a TODO to revert once support is available.

Changes:
- Commented out npm OIDC token generation step
- Commented out npm dist-tag add step  
- Added TODO comment for future reversion