### PR TITLE
fix(cloudfront-function): always add `cloudfront` as external dependency

### DIFF
--- a/src/cloudfront-function-code.ts
+++ b/src/cloudfront-function-code.ts
@@ -134,6 +134,7 @@ class EsbuildFunctionCode extends FunctionCode {
       format: 'esm',
       target: 'es5',
       platform: 'neutral',
+      external: ['cloudfront', ...(props.buildOptions?.external ?? [])],
       ...minifyOptions(props.buildOptions?.minify),
       supported: {
         ...props.buildOptions?.supported,
@@ -219,7 +220,6 @@ function minifyOptions(minify: boolean = false) {
       minifyWhitespace: false,
       minifySyntax: false,
       minifyIdentifiers: false,
-
     };
   }
 

--- a/test/cloudfront-function-code.test.ts
+++ b/test/cloudfront-function-code.test.ts
@@ -52,6 +52,28 @@ describe('CloudFrontTypeScriptCode', () => {
       expect(buildOptions.minify).toBe(false);
     });
 
+    test('always includes cloudfront as external and preserves custom externals', () => {
+      const code = CloudFrontTypeScriptCode.fromFile('test/fixtures/handlers/cf-handler.ts', {
+        buildOptions: {
+          external: ['aws-sdk', 'lodash'],
+        },
+      });
+
+      const bundler = (code as any).bundler;
+      const buildOptions = (bundler as any).props.buildOptions;
+
+      expect(buildOptions.external).toEqual(['cloudfront', 'aws-sdk', 'lodash']);
+    });
+
+    test('includes cloudfront as external when no custom externals provided', () => {
+      const code = CloudFrontTypeScriptCode.fromFile('test/fixtures/handlers/cf-handler.ts');
+
+      const bundler = (code as any).bundler;
+      const buildOptions = (bundler as any).props.buildOptions;
+
+      expect(buildOptions.external).toEqual(['cloudfront']);
+    });
+
     test('renders bundled code', () => {
       const code = CloudFrontTypeScriptCode.fromFile('test/fixtures/handlers/cf-handler.ts');
 


### PR DESCRIPTION
This change ensures that 'cloudfront' is always included in the external dependencies for CloudFront function code, while preserving any custom external dependencies provided by users. The module is ambiently available in the runtime.

## Changes
- Added 'cloudfront' to the external array in CloudFront function code build options
- Added comprehensive tests to verify the behavior with and without custom externals

## Testing
- ✅ Test for preserving custom externals alongside cloudfront
- ✅ Test for default behavior when no custom externals provided