### PR TITLE
chore(release): use GitHub App token for Go module publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5
         with:
           app-id: ${{ secrets.PROJEN_APP_ID }}
           private-key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
@@ -96,8 +96,6 @@ jobs:
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
       - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_SHA 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
   release_npm:
     name: Publish to npm
@@ -140,8 +138,6 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
-    env:
-      NPM_CONFIG_PROVENANCE: "true"
   release_maven:
     name: Publish to Maven Central
     needs: release
@@ -311,16 +307,19 @@ jobs:
         run: cd .repo && npx projen package:go
       - name: Collect go artifact
         run: mv .repo/dist dist
-      - name: Setup GitHub deploy key
-        env:
-          GITHUB_DEPLOY_KEY: ${{ secrets.GO_DEPLOY_KEY }}
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: ssh-agent -a ${SSH_AUTH_SOCK} && ssh-add - <<< "${GITHUB_DEPLOY_KEY}"
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5
+        with:
+          app-id: ${{ secrets.PROJEN_APP_ID }}
+          private-key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: cdk-esbuild-go
+          permission-contents: write
       - name: Release
         env:
           GIT_USER_NAME: github-actions[bot]
           GIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GITHUB_USE_SSH: "true"
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GIT_BRANCH: v5
         run: npx -p publib@latest publib-golang

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -110,8 +110,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
   publishToGo: {
     moduleName: 'github.com/mrgrain/cdk-esbuild-go',
     packageName: 'cdkesbuild',
-    githubUseSsh: true,
-    githubDeployKeySecret: 'GO_DEPLOY_KEY',
   },
   publishToMaven: {
     mavenServerId: 'central-ossrh',

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -35,11 +35,11 @@
         },
         "aws-cdk.asset-awscli-v1": {
             "hashes": [
-                "sha256:2426ee075948d665ca4a2e7f6d822ef2e901496f7f63ea21409234d239fd3703",
-                "sha256:2a5a9b41755424e5409dc415fc7db8a723472bded04a2c96d76f83efcd8899a1"
+                "sha256:79d6c5781b5d4276f6b3b18163e35df5c1fda1f98a6661a34a1ecb15928fce29",
+                "sha256:8fbc8645d45abc61508f5b2392dd62a3798e2f3ce190edfe634e3da0b977ac18"
             ],
             "markers": "python_version ~= '3.9'",
-            "version": "==2.2.259"
+            "version": "==2.2.260"
         },
         "aws-cdk.asset-kubectl-v20": {
             "hashes": [

--- a/projenrc/ReleaseBranches.ts
+++ b/projenrc/ReleaseBranches.ts
@@ -1,4 +1,4 @@
-import { JsonPatch, release, typescript } from 'projen';
+import { github, JsonPatch, release, typescript } from 'projen';
 import { VersionsFile } from './VersionsFile';
 
 export interface StableReleaseBranchOptions extends Omit<release.BranchOptions, 'npmDistTag'> {
@@ -49,6 +49,17 @@ export class StableReleases {
       project.addDevDeps( `@aws-cdk/aws-synthetics-alpha@${opts.syntheticsVersion ?? opts.cdkVersion + '-alpha.0'}`);
     };
 
+
+    const appToken = (repositories?: string[], permissions?: github.workflows.AppPermissions) => {
+      return github.GithubCredentials.fromApp({
+        appIdSecret: 'PROJEN_APP_ID',
+        privateKeySecret: 'PROJEN_APP_PRIVATE_KEY',
+        owner: repositories ? '${{ github.repository_owner }}' : undefined,
+        repositories,
+        permissions,
+      });
+    };
+
     /**
      * Configure features for all branches
      */
@@ -59,18 +70,11 @@ export class StableReleases {
       releaseWorkflow?.patch(JsonPatch.replace('/on/schedule', [{ cron: opts.releaseSchedule }]));
 
       // Use the app to publish the changelog
+      const releaseToken = appToken();
       releaseWorkflow?.patch(
         JsonPatch.add('/jobs/release/environment', 'automation'),
-        JsonPatch.add('/jobs/release/steps/0', {
-          name: 'Generate token',
-          id: 'generate_token',
-          uses: 'actions/create-github-app-token@v1',
-          with: {
-            'app-id': '${{ secrets.PROJEN_APP_ID }}',
-            'private-key': '${{ secrets.PROJEN_APP_PRIVATE_KEY }}',
-          },
-        }),
-        JsonPatch.add('/jobs/release/steps/1/with/token', '${{ steps.generate_token.outputs.token }}'),
+        JsonPatch.add('/jobs/release/steps/0', releaseToken.setupSteps[0]),
+        JsonPatch.add('/jobs/release/steps/1/with/token', releaseToken.tokenRef),
       );
 
       // Check out the correct ref
@@ -103,13 +107,18 @@ export class StableReleases {
         // releaseWorkflow?.patch(JsonPatch.add('/jobs/release_npm/steps/-', tagOnNpm(opts.npmDistTags)));
       }
 
-      // Go branch
-      releaseWorkflow?.patch(JsonPatch.add('/jobs/release_golang/steps/11/env/GIT_BRANCH', branch));
+      // release: GitHub
+      releaseWorkflow?.patch(JsonPatch.remove('/jobs/release_github/steps/3/env'));
 
-      // npm provenance information
+      // release: Go
+      const goPublishToken = appToken(
+        [project.package.manifest.jsii?.targets?.go?.moduleName?.split('/').pop()],
+        { contents: github.workflows.AppPermission.WRITE },
+      );
       releaseWorkflow?.patch(
-        JsonPatch.add('/jobs/release_npm/env', { NPM_CONFIG_PROVENANCE: 'true' }),
-        JsonPatch.add('/jobs/release_npm/permissions/id-token', 'write'),
+        JsonPatch.add('/jobs/release_golang/steps/10', goPublishToken.setupSteps[0]),
+        JsonPatch.add('/jobs/release_golang/steps/11/env/GITHUB_TOKEN', goPublishToken.tokenRef),
+        JsonPatch.add('/jobs/release_golang/steps/11/env/GIT_BRANCH', branch),
       );
     };
 


### PR DESCRIPTION
Replaces the SSH deploy key authentication with GitHub App tokens for publishing Go modules to the `cdk-esbuild-go` repository.

The SSH deploy key approach required managing a separate secret and using SSH agent setup. Using the existing GitHub App (already configured for other release automation) simplifies the authentication flow and provides better auditability.

This change also refactors the release workflow to use projen's `GithubCredentials.fromApp()` helper, ensuring consistent token generation across all release jobs that need elevated permissions.
