### PR TITLE
fix(release): use automation environment for Go release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    environment: release
+    environment: automation
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5

--- a/projenrc/ReleaseBranches.ts
+++ b/projenrc/ReleaseBranches.ts
@@ -57,6 +57,7 @@ export class StableReleases {
         owner: repositories ? '${{ github.repository_owner }}' : undefined,
         repositories,
         permissions,
+        environment: 'automation',
       });
     };
 
@@ -72,7 +73,7 @@ export class StableReleases {
       // Use the app to publish the changelog
       const releaseToken = appToken();
       releaseWorkflow?.patch(
-        JsonPatch.add('/jobs/release/environment', 'automation'),
+        JsonPatch.add('/jobs/release/environment', releaseToken.environment),
         JsonPatch.add('/jobs/release/steps/0', releaseToken.setupSteps[0]),
         JsonPatch.add('/jobs/release/steps/1/with/token', releaseToken.tokenRef),
       );
@@ -116,6 +117,7 @@ export class StableReleases {
         { contents: github.workflows.AppPermission.WRITE },
       );
       releaseWorkflow?.patch(
+        JsonPatch.add('/jobs/release_golang/environment', goPublishToken.environment),
         JsonPatch.add('/jobs/release_golang/steps/10', goPublishToken.setupSteps[0]),
         JsonPatch.add('/jobs/release_golang/steps/11/env/GITHUB_TOKEN', goPublishToken.tokenRef),
         JsonPatch.add('/jobs/release_golang/steps/11/env/GIT_BRANCH', branch),


### PR DESCRIPTION
Fixes the Go release job to use the correct `automation` environment.

The `release_golang` job was using the `release` environment while all other jobs using GitHub App tokens use `automation`. This caused the Go release to fail because the required secrets are only available in the `automation` environment.

This change also refactors the environment configuration to use the token's environment property directly, making the code more maintainable and consistent.
