### PR TITLE
chore: use correct token format for Go publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,6 @@ jobs:
         env:
           GIT_USER_NAME: github-actions[bot]
           GIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: x-access-token:${{ steps.generate_token.outputs.token }}
           GIT_BRANCH: v5
         run: npx -p publib@latest publib-golang

--- a/projenrc/ReleaseBranches.ts
+++ b/projenrc/ReleaseBranches.ts
@@ -117,7 +117,7 @@ export class StableReleases {
       );
       releaseWorkflow?.patch(
         JsonPatch.add('/jobs/release_golang/steps/10', goPublishToken.setupSteps[0]),
-        JsonPatch.add('/jobs/release_golang/steps/11/env/GITHUB_TOKEN', goPublishToken.tokenRef),
+        JsonPatch.add('/jobs/release_golang/steps/11/env/GITHUB_TOKEN', `x-access-token:${goPublishToken.tokenRef}`),
         JsonPatch.add('/jobs/release_golang/steps/11/env/GIT_BRANCH', branch),
       );
     };


### PR DESCRIPTION
Fixes the Go release workflow by using the correct token format for git authentication.

When using GitHub App tokens with `publib-golang`, the `GITHUB_TOKEN` environment variable needs to include the `x-access-token:` prefix for git operations to authenticate correctly. Without this prefix, the token is not recognized as valid credentials.
