### PR TITLE
chore(release): add GITHUB_TOKEN env to GitHub release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,8 @@ jobs:
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
       - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_SHA 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
   release_npm:
     name: Publish to npm

--- a/projenrc/ReleaseBranches.ts
+++ b/projenrc/ReleaseBranches.ts
@@ -108,9 +108,6 @@ export class StableReleases {
         // releaseWorkflow?.patch(JsonPatch.add('/jobs/release_npm/steps/-', tagOnNpm(opts.npmDistTags)));
       }
 
-      // release: GitHub
-      releaseWorkflow?.patch(JsonPatch.remove('/jobs/release_github/steps/3/env'));
-
       // release: Go
       const goPublishToken = appToken(
         [project.package.manifest.jsii?.targets?.go?.moduleName?.split('/').pop()],


### PR DESCRIPTION
The previous patch was removing the `env` block from the GitHub release step, which inadvertently removed the `GITHUB_TOKEN` that the `gh` CLI needs for authentication.

This change stops removing the env block and instead explicitly sets `GITHUB_TOKEN` to ensure the release step has proper authentication when creating GitHub releases.
