### PR TITLE
chore(release): skip release workflow when last commit was a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
           overwrite: true
       - name: Publish Changelog
         run: npx projen publish:git:v5
+    needs: check
+    if: needs.check.outputs.has_changes == 'true'
     environment: automation
   release_github:
     name: Publish to GitHub Releases
@@ -325,3 +327,17 @@ jobs:
           GITHUB_TOKEN: x-access-token:${{ steps.generate_token.outputs.token }}
           GIT_BRANCH: v5
         run: npx -p publib@latest publib-golang
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.changes.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - id: changes
+        run: |-
+          if git log --oneline -1 | grep -qv "chore(release):"; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi

--- a/projenrc/ReleaseBranches.ts
+++ b/projenrc/ReleaseBranches.ts
@@ -70,6 +70,29 @@ export class StableReleases {
       // Release schedule
       releaseWorkflow?.patch(JsonPatch.replace('/on/schedule', [{ cron: opts.releaseSchedule }]));
 
+      // Don't run the workflow if the last commit was a release
+      releaseWorkflow?.patch(
+        JsonPatch.add('/jobs/check', {
+          'runs-on': 'ubuntu-latest',
+          'outputs': {
+            has_changes: '${{ steps.changes.outputs.has_changes }}',
+          },
+          'steps': [
+            github.WorkflowSteps.checkout(),
+            {
+              id: 'changes',
+              run: `if git log --oneline -1 | grep -qv "chore(release):"; then
+  echo "has_changes=true" >> $GITHUB_OUTPUT
+else
+  echo "has_changes=false" >> $GITHUB_OUTPUT
+fi`,
+            },
+          ],
+        }),
+        JsonPatch.add('/jobs/release/needs', 'check'),
+        JsonPatch.add('/jobs/release/if', "needs.check.outputs.has_changes == 'true'"),
+      );
+
       // Use the app to publish the changelog
       const releaseToken = appToken();
       releaseWorkflow?.patch(


### PR DESCRIPTION
The scheduled release workflow currently runs even when the last commit is already a release commit (e.g., `chore(release): v5.x.x`). This causes unnecessary workflow runs that produce no artifacts.

This change adds a `check` job that inspects the last commit message. If it matches the release commit pattern, the release job is skipped entirely. This prevents wasted CI minutes and avoids potential issues from running the release process when there's nothing new to release.

Fixes #
